### PR TITLE
fix: prevent infinite DB polling loop in makeNSView

### DIFF
--- a/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
+++ b/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
@@ -64,10 +64,13 @@ struct ClaudeSessionTerminalView: NSViewRepresentable {
        }),
        let permSettings = record.decodedPermissionSettings {
       // Store the hash of what we're launching with so the Inspector can detect changes
-      try? AppDatabase.shared.databaseWriter.write { db in
-        if var rec = try SessionRecord.fetchOne(db, key: terminalId) {
-          rec.launchedPermissionsHash = permSettings.contentHash
-          try rec.update(db)
+      let newHash = permSettings.contentHash
+      if record.launchedPermissionsHash != newHash {
+        try? AppDatabase.shared.databaseWriter.write { db in
+          if var rec = try SessionRecord.fetchOne(db, key: terminalId) {
+            rec.launchedPermissionsHash = newHash
+            try rec.update(db)
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- `ClaudeSessionTerminalView.makeNSView` unconditionally wrote `launchedPermissionsHash` to the DB on every call
- This triggered `@Query<SessionByTerminalIdRequest>` observers, causing SwiftUI to re-render and call `makeNSView` again — an infinite loop
- Fix: compare the hash before writing; skip the DB write when unchanged

## Test plan
- [ ] Launch a Claude session and verify no repeating `SELECT * FROM "sessionRecord"` in console
- [ ] Change permissions in Inspector and verify `launchedPermissionsHash` still updates correctly
- [ ] Verify "Restart with New Permissions" button still appears after permission edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)