### PR TITLE
fix: preserve terminal process when dragging split pane to new window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,8 @@ SwiftUI destroys and recreates `NSViewRepresentable`-backed views when they move
 - `GhosttyTerminalView.makeNSView`: returns cached view if `existingHostView != nil`, skipping `setup()` (no new process).
 - `onHostViewCreated` callback: fires in `makeNSView` for fresh views, allowing callers to populate the cache.
 - Cache is evicted in `closeSplitPane(id:)` and `closeSplit()` before deactivating, so the Ghostty process terminates when the pane is explicitly closed.
+- **Container wrapper**: `makeNSView` returns `GhosttyHostViewContainer` (thin NSView wrapper), not `GhosttyHostView` directly. SwiftUI manages the container's lifecycle — when a split tree change destroys the old wrapper, only the container is removed. The actual `GhosttyHostView` survives in the ViewModel cache. This mirrors Ghostty's `SurfaceScrollView`/`SurfaceRepresentable` pattern.
+- **Cross-window transfer**: `handleDragToNewWindow` extracts the host view from the source cache, creates a new `ContentViewModel` with `preloadForTransfer()` (host view pre-loaded), then creates the new window via `NSWindow` + `NSHostingController` (not `NSApp.sendAction(newWindowForTab)`). The source split tree is modified AFTER the new window has the host view — no orphan gap.
 
 #### Pane Headers & Drag-to-Rearrange
 
@@ -319,7 +321,7 @@ Every pane (single or split) has a `PaneHeaderView` at the top: 30px height, ses
 
 **Title source**: Claude sessions use `session.title`; plain terminals use `GhosttyEmbedSurface.title` (auto-updates from terminal escape sequences via `@Published`).
 
-**Cross-window ready**: Pasteboard uses string-based `terminalId` (not object references). `Notification.paneDragEndedNoTarget` is posted when a drag ends outside any window, enabling future cross-window pane transfer.
+**Drag outside window**: When a drag ends outside all visible windows, `Notification.paneDragEndedNoTarget` fires. `ContentViewModel.handlePaneDragToNewWindow` handles it: solo sessions (no split) are a no-op; split panes are transferred to a new AppKit-created window via `handleDragToNewWindow` (see GhosttyHostView Cache above).
 
 #### File Drag & Drop
 

--- a/Tenvy/App/ContentView.swift
+++ b/Tenvy/App/ContentView.swift
@@ -46,6 +46,11 @@ struct ContentView: View {
     _viewModel = State(initialValue: ContentViewModel(appModel: appModel))
   }
 
+  /// Creates a ContentView with a pre-configured ViewModel (for cross-window transfers).
+  init(viewModel: ContentViewModel) {
+    _viewModel = State(initialValue: viewModel)
+  }
+
   // Delegate prompt visibility to the ViewModel (which reads from appModel services)
   private var hookPromptVisible: Bool { viewModel.hookPromptVisible }
   private var notificationPromptVisible: Bool { viewModel.notificationPromptVisible }

--- a/Tenvy/App/ContentViewModel.swift
+++ b/Tenvy/App/ContentViewModel.swift
@@ -24,6 +24,8 @@ import AppKit
 import Combine
 import Foundation
 import GhosttyEmbed
+import GRDBQuery
+import SwiftUI
 
 // MARK: - Worktree Split Types
 
@@ -443,6 +445,13 @@ final class ContentViewModel {
   private func handlePaneDragToNewWindow(terminalId: String) {
     // Find the session by terminalId
     guard let session = findSessionByTerminalId(terminalId) else { return }
+
+    // If this session is already alone in its window (no split), dragging outside is a no-op.
+    // The session is already in a dedicated window — nothing to detach from.
+    if !isInSplitMode && selectedSession?.id == session.id {
+      return
+    }
+
     handleDragToNewWindow(sessionId: session.id)
   }
 
@@ -457,18 +466,109 @@ final class ContentViewModel {
 
   /// Handle a session dragged to the "New Window" drop zone.
   /// Transfers the host view to a new window without restarting the process.
+  ///
+  /// Mirrors Ghostty's `ghosttySurfaceDragEndedNoTarget` pattern:
+  /// 1. Extract host view from source cache
+  /// 2. Create new window with pre-configured ViewModel (host view already loaded)
+  /// 3. THEN remove session from source split tree
+  /// This ensures the host view is owned by the new ViewModel before SwiftUI
+  /// destroys the old wrapper in the source window's re-render.
   func handleDragToNewWindow(sessionId: String) {
     guard let session = appModel.activatedSessions[sessionId] else { return }
 
-    // Release from current location (deposits host view on AppModel)
-    appModel.releaseSessionForTransfer(sessionId: sessionId)
+    // 1. Extract host view from source cache (without modifying split tree yet)
+    let hostView = ghosttyHostViews.removeValue(forKey: session.terminalId)
 
-    // The host view stays on AppModel's transfer store —
-    // the new window's ViewModel picks it up via ghosttyHostView(for:) auto-pickup.
+    // 2. Create new ViewModel pre-loaded with session and host view
+    let newVM = ContentViewModel(appModel: appModel)
+    newVM.preloadForTransfer(session: session, hostView: hostView, isPlainTerminal: isPlainTerminal(session.terminalId))
+
+    // 3. Create new window using AppKit (like Ghostty's TerminalController.newWindow)
+    let rootView = ContentView(viewModel: newVM)
+      .environment(appModel)
+      .databaseContext(.readOnly { AppDatabase.shared.databaseReader })
+    let hostingController = NSHostingController(rootView: rootView)
+    let window = NSWindow(
+      contentRect: .zero,
+      styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
+    )
+    window.contentViewController = hostingController
+    window.titlebarAppearsTransparent = true
+    window.titleVisibility = .visible
+    window.isOpaque = false
+    window.backgroundColor = .clear
+    window.title = session.title
+
+    // Size to match source window
+    if let sourceFrame = currentWindow?.frame {
+      window.setFrame(sourceFrame, display: false)
+    } else {
+      window.setContentSize(NSSize(width: 800, height: 600))
+    }
+
+    window.makeKeyAndOrderFront(nil)
+
+    // 4. NOW remove from source split tree (safe — host view is in new ViewModel)
+    removePaneFromSource(sessionId: sessionId)
+  }
+
+  /// Pre-load a session and host view for a cross-window transfer.
+  /// Called on the destination ViewModel before the window is shown.
+  func preloadForTransfer(session: ClaudeSession, hostView: GhosttyHostView?, isPlainTerminal: Bool) {
+    selectedSession = session
     appModel.activateSession(session)
-    windowRegistry.pendingSessionForNewTab = session
-    currentWindow?.selectNextTab(nil)
-    NSApp.sendAction(#selector(NSWindow.newWindowForTab(_:)), to: nil, from: nil)
+    if let hostView {
+      ghosttyHostViews[session.terminalId] = hostView
+    }
+    if isPlainTerminal {
+      plainTerminalIds.insert(session.terminalId)
+      if let surface = hostView?.surface {
+        titleCancellables[session.terminalId] = surface.titlePublisher
+          .receive(on: DispatchQueue.main)
+          .sink { [weak self] newTitle in
+            self?.plainTerminalTitles[session.terminalId] = newTitle.isEmpty ? "Terminal" : newTitle
+          }
+      }
+    }
+  }
+
+  /// Remove a session from this window's split tree / selection after transfer.
+  private func removePaneFromSource(sessionId: String) {
+    if isInSplitMode && splitTree?.contains(sessionId: sessionId) == true {
+      let wasSelected = selectedSession?.id == sessionId
+      let wasPrimary = currentWindow?.sessionId == sessionId
+
+      if let newTree = splitTree?.removing(sessionId: sessionId) {
+        let remaining = newTree.allSessions
+        if remaining.count <= 1 {
+          splitTree = nil
+          if wasSelected { selectedSession = remaining.first ?? primarySession }
+        } else {
+          splitTree = newTree
+          if wasSelected { selectedSession = primarySession ?? remaining.first }
+        }
+      } else {
+        splitTree = nil
+        if wasSelected { selectedSession = nil }
+      }
+
+      if wasPrimary {
+        bindWindowToSession(splitTree?.allSessions.first ?? selectedSession)
+      }
+    } else {
+      selectedSession = nil
+      bindWindowToSession(nil)
+    }
+
+    // Close the now-empty window (unless it's the last visible one)
+    if selectedSession == nil && !isInSplitMode, let window = currentWindow {
+      let visibleWindows = NSApp.windows.filter { $0.isVisible && $0 != window }
+      if !visibleWindows.isEmpty {
+        window.close()
+      }
+    }
   }
 
   /// Create and select a new session

--- a/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
+++ b/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
@@ -36,87 +36,96 @@ struct ClaudeSessionTerminalView: NSViewRepresentable {
   let onHostViewCreated: ((GhosttyHostView) -> Void)?
   @Environment(\.colorScheme) private var colorScheme
 
-  func makeNSView(context: Context) -> GhosttyHostView {
-    if let existing = existingHostView { return existing }
+  /// Returns a thin container NSView that wraps the GhosttyHostView.
+  /// SwiftUI manages the container — the GhosttyHostView is a child that can be
+  /// reparented to a different container during cross-window transfers without
+  /// SwiftUI destroying the running Ghostty process (mirrors Ghostty's own
+  /// SurfaceScrollView / SurfaceRepresentable pattern).
+  func makeNSView(context: Context) -> GhosttyHostViewContainer {
+    let hostView: GhosttyHostView
+    if let existing = existingHostView {
+      hostView = existing
+    } else {
+      hostView = GhosttyHostView()
+      let workingDirectory = session?.workingDirectory ?? NSHomeDirectory()
 
-    let hostView = GhosttyHostView()
-    let workingDirectory = session?.workingDirectory ?? NSHomeDirectory()
+      let claudePath = ClaudePathResolver.findClaudePath()
+      var args: [String] = []
+      if let forkId = forkSourceSessionId {
+        args = ["--resume", forkId, "--fork-session"]
+      } else if let session = session, !session.isNewSession {
+        args = ["--resume", session.id]
+      }
 
-    let claudePath = ClaudePathResolver.findClaudePath()
-    var args: [String] = []
-    if let forkId = forkSourceSessionId {
-      args = ["--resume", forkId, "--fork-session"]
-    } else if let session = session, !session.isNewSession {
-      args = ["--resume", session.id]
-    }
-
-    // Apply per-session permission settings as CLI flags and record the launch hash.
-    //
-    // CLI flags are ADDITIVE — they can't remove permissions already granted by
-    // ~/.claude/settings.json or project settings. To handle removals:
-    // - Compare per-session allow list against inherited (global+project) allow list
-    // - Tools removed by the user → pass as --disallowedTools (deny overrides allow)
-    // - Tools added by the user → pass as --allowedTools
-    // - Explicit deny list → also passed as --disallowedTools
-    if let terminalId = session?.terminalId,
-       let record = try? AppDatabase.shared.databaseReader.read({ db in
-         try SessionRecord.fetchOne(db, key: terminalId)
-       }),
-       let permSettings = record.decodedPermissionSettings {
-      // Store the hash of what we're launching with so the Inspector can detect changes
-      let newHash = permSettings.contentHash
-      if record.launchedPermissionsHash != newHash {
-        try? AppDatabase.shared.databaseWriter.write { db in
-          if var rec = try SessionRecord.fetchOne(db, key: terminalId) {
-            rec.launchedPermissionsHash = newHash
-            try rec.update(db)
+      // Apply per-session permission settings as CLI flags and record the launch hash.
+      //
+      // CLI flags are ADDITIVE — they can't remove permissions already granted by
+      // ~/.claude/settings.json or project settings. To handle removals:
+      // - Compare per-session allow list against inherited (global+project) allow list
+      // - Tools removed by the user → pass as --disallowedTools (deny overrides allow)
+      // - Tools added by the user → pass as --allowedTools
+      // - Explicit deny list → also passed as --disallowedTools
+      if let terminalId = session?.terminalId,
+         let record = try? AppDatabase.shared.databaseReader.read({ db in
+           try SessionRecord.fetchOne(db, key: terminalId)
+         }),
+         let permSettings = record.decodedPermissionSettings {
+        // Store the hash of what we're launching with so the Inspector can detect changes
+        let newHash = permSettings.contentHash
+        if record.launchedPermissionsHash != newHash {
+          try? AppDatabase.shared.databaseWriter.write { db in
+            if var rec = try SessionRecord.fetchOne(db, key: terminalId) {
+              rec.launchedPermissionsHash = newHash
+              try rec.update(db)
+            }
           }
+        }
+
+        args.append(contentsOf: ["--permission-mode", permSettings.permissionMode.rawValue])
+
+        // Compute what was inherited so we can detect removals
+        let inherited = ClaudeSettingsService.mergeForNewSession(
+          projectPath: session?.projectPath ?? ""
+        )
+
+        // Tools the user explicitly allows (pass as --allowedTools)
+        if !permSettings.permissions.allow.isEmpty {
+          args.append("--allowedTools")
+          args.append(permSettings.permissions.allow.joined(separator: " "))
+        }
+
+        // Tools to deny: explicit deny list + tools removed from inherited allow list.
+        // Deny rules override allow rules at any scope, so this effectively revokes
+        // permissions that global/project settings would otherwise grant.
+        let removedFromAllow = Set(inherited.permissions.allow)
+          .subtracting(permSettings.permissions.allow)
+        let allDenied = Set(permSettings.permissions.deny).union(removedFromAllow)
+        if !allDenied.isEmpty {
+          args.append("--disallowedTools")
+          args.append(allDenied.joined(separator: " "))
         }
       }
 
-      args.append(contentsOf: ["--permission-mode", permSettings.permissionMode.rawValue])
+      let launch = TerminalEnvironment.shellArgs(executable: claudePath, args: args, currentDirectory: session?.workingDirectory ?? NSHomeDirectory(), initScript: initScript)
 
-      // Compute what was inherited so we can detect removals
-      let inherited = ClaudeSettingsService.mergeForNewSession(
-        projectPath: session?.projectPath ?? ""
-      )
-
-      // Tools the user explicitly allows (pass as --allowedTools)
-      if !permSettings.permissions.allow.isEmpty {
-        args.append("--allowedTools")
-        args.append(permSettings.permissions.allow.joined(separator: " "))
+      hostView.setupSurface(launch: launch, workingDirectory: session?.workingDirectory ?? NSHomeDirectory(), terminalId: session?.terminalId, onAction: onAction)
+      hostView.contextMenuProvider = { [weak hostView] in
+        guard let hostView else { return NSMenu() }
+        let target = SessionMenuTarget(onAction: hostView.onAction)
+        hostView.menuTarget = target
+        return Self.buildMenu(surfaceView: hostView.surfaceViewIfReady, target: target)
       }
+      hostView.setupMonitoring(sessionId: session?.id, isNewSession: session?.isNewSession ?? false)
 
-      // Tools to deny: explicit deny list + tools removed from inherited allow list.
-      // Deny rules override allow rules at any scope, so this effectively revokes
-      // permissions that global/project settings would otherwise grant.
-      let removedFromAllow = Set(inherited.permissions.allow)
-        .subtracting(permSettings.permissions.allow)
-      let allDenied = Set(permSettings.permissions.deny).union(removedFromAllow)
-      if !allDenied.isEmpty {
-        args.append("--disallowedTools")
-        args.append(allDenied.joined(separator: " "))
-      }
+      if isSelected { hostView.pendingFocus = true }
+      onHostViewCreated?(hostView)
     }
 
-    let launch = TerminalEnvironment.shellArgs(executable: claudePath, args: args, currentDirectory: workingDirectory, initScript: initScript)
-
-    hostView.setupSurface(launch: launch, workingDirectory: workingDirectory, terminalId: session?.terminalId, onAction: onAction)
-    hostView.contextMenuProvider = { [weak hostView] in
-      guard let hostView else { return NSMenu() }
-      let target = SessionMenuTarget(onAction: hostView.onAction)
-      hostView.menuTarget = target
-      return Self.buildMenu(surfaceView: hostView.surfaceViewIfReady, target: target)
-    }
-    hostView.setupMonitoring(sessionId: session?.id, isNewSession: session?.isNewSession ?? false)
-
-    if isSelected { hostView.pendingFocus = true }
-    onHostViewCreated?(hostView)
-    return hostView
+    return GhosttyHostViewContainer(hostView: hostView)
   }
 
-  func updateNSView(_ nsView: GhosttyHostView, context: Context) {
-    nsView.onAction = onAction
+  func updateNSView(_ container: GhosttyHostViewContainer, context: Context) {
+    container.hostView.onAction = onAction
 
     if context.coordinator.lastColorScheme != colorScheme {
       context.coordinator.lastColorScheme = colorScheme
@@ -129,16 +138,17 @@ struct ClaudeSessionTerminalView: NSViewRepresentable {
     // Only grab focus on the transition from deselected → selected,
     // not on every re-render while selected (which steals focus from dialogs/dropdowns).
     if isSelected && !wasSelected {
-      if nsView.window != nil {
+      let hostView = container.hostView
+      if hostView.window != nil {
         DispatchQueue.main.async {
-          guard let surfaceView = nsView.surfaceViewIfReady, nsView.window != nil else { return }
-          let fr = nsView.window?.firstResponder as? NSView
+          guard let surfaceView = hostView.surfaceViewIfReady, hostView.window != nil else { return }
+          let fr = hostView.window?.firstResponder as? NSView
           if fr == nil || !(fr!.isDescendant(of: surfaceView)) {
-            nsView.makeFocused()
+            hostView.makeFocused()
           }
         }
       } else {
-        nsView.pendingFocus = true
+        hostView.pendingFocus = true
       }
     }
   }

--- a/Tenvy/Features/Terminal/GhosttyHostView.swift
+++ b/Tenvy/Features/Terminal/GhosttyHostView.swift
@@ -297,3 +297,35 @@ final class GhosttyHostView: NSView {
     }
   }
 }
+
+// MARK: - GhosttyHostViewContainer
+
+/// Thin wrapper NSView returned by NSViewRepresentable's makeNSView.
+///
+/// SwiftUI manages this container's lifecycle (add/removeFromSuperview). The actual
+/// GhosttyHostView lives as a child and can be reparented to a different container
+/// during cross-window transfers — SwiftUI destroys the old container but the
+/// GhosttyHostView (and its running Ghostty process) survives in the ViewModel cache.
+///
+/// This mirrors Ghostty's own SurfaceScrollView / SurfaceRepresentable pattern where
+/// the surface view is never directly managed by SwiftUI.
+final class GhosttyHostViewContainer: NSView {
+  let hostView: GhosttyHostView
+
+  init(hostView: GhosttyHostView) {
+    self.hostView = hostView
+    super.init(frame: .zero)
+    hostView.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(hostView)
+    NSLayoutConstraint.activate([
+      hostView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      hostView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      hostView.topAnchor.constraint(equalTo: topAnchor),
+      hostView.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) { fatalError() }
+
+  override var isFlipped: Bool { true }
+}

--- a/Tenvy/Features/Terminal/PlainTerminalView.swift
+++ b/Tenvy/Features/Terminal/PlainTerminalView.swift
@@ -35,30 +35,36 @@ struct PlainTerminalView: NSViewRepresentable {
   let onHostViewCreated: ((GhosttyHostView) -> Void)?
   @Environment(\.colorScheme) private var colorScheme
 
-  func makeNSView(context: Context) -> GhosttyHostView {
-    if let existing = existingHostView { return existing }
+  /// Returns a thin container NSView that wraps the GhosttyHostView.
+  /// See ClaudeSessionTerminalView.makeNSView for why.
+  func makeNSView(context: Context) -> GhosttyHostViewContainer {
+    let hostView: GhosttyHostView
+    if let existing = existingHostView {
+      hostView = existing
+    } else {
+      hostView = GhosttyHostView()
+      let launch = TerminalEnvironment.plainShellArgs(currentDirectory: workingDirectory, initScript: initScript)
 
-    let hostView = GhosttyHostView()
-    let launch = TerminalEnvironment.plainShellArgs(currentDirectory: workingDirectory, initScript: initScript)
+      hostView.setupSurface(launch: launch, workingDirectory: workingDirectory, onAction: onAction)
+      hostView.contextMenuProvider = { [weak hostView] in
+        guard let hostView else { return NSMenu() }
+        let target = PlainTerminalMenuTarget(
+          onAction: hostView.onAction,
+          onReset: { [weak hostView] in hostView?.resetTerminal() }
+        )
+        hostView.menuTarget = target
+        return Self.buildMenu(surfaceView: hostView.surfaceViewIfReady, target: target)
+      }
 
-    hostView.setupSurface(launch: launch, workingDirectory: workingDirectory, onAction: onAction)
-    hostView.contextMenuProvider = { [weak hostView] in
-      guard let hostView else { return NSMenu() }
-      let target = PlainTerminalMenuTarget(
-        onAction: hostView.onAction,
-        onReset: { [weak hostView] in hostView?.resetTerminal() }
-      )
-      hostView.menuTarget = target
-      return Self.buildMenu(surfaceView: hostView.surfaceViewIfReady, target: target)
+      if isSelected { hostView.pendingFocus = true }
+      onHostViewCreated?(hostView)
     }
 
-    if isSelected { hostView.pendingFocus = true }
-    onHostViewCreated?(hostView)
-    return hostView
+    return GhosttyHostViewContainer(hostView: hostView)
   }
 
-  func updateNSView(_ nsView: GhosttyHostView, context: Context) {
-    nsView.onAction = onAction
+  func updateNSView(_ container: GhosttyHostViewContainer, context: Context) {
+    container.hostView.onAction = onAction
 
     if context.coordinator.lastColorScheme != colorScheme {
       context.coordinator.lastColorScheme = colorScheme
@@ -71,16 +77,17 @@ struct PlainTerminalView: NSViewRepresentable {
     // Only grab focus on the transition from deselected → selected,
     // not on every re-render while selected (which steals focus from dialogs/dropdowns).
     if isSelected && !wasSelected {
-      if nsView.window != nil {
+      let hostView = container.hostView
+      if hostView.window != nil {
         DispatchQueue.main.async {
-          guard let surfaceView = nsView.surfaceViewIfReady, nsView.window != nil else { return }
-          let fr = nsView.window?.firstResponder as? NSView
+          guard let surfaceView = hostView.surfaceViewIfReady, hostView.window != nil else { return }
+          let fr = hostView.window?.firstResponder as? NSView
           if fr == nil || !(fr!.isDescendant(of: surfaceView)) {
-            nsView.makeFocused()
+            hostView.makeFocused()
           }
         }
       } else {
-        nsView.pendingFocus = true
+        hostView.pendingFocus = true
       }
     }
   }


### PR DESCRIPTION
## Summary

- **Split pane drag-outside**: Dragging a pane outside the window now opens it in a new window without restarting the terminal/Claude session. Previously the Ghostty process was killed during the transfer because SwiftUI destroyed the host view during the source window re-render.
- **Solo session drag-outside**: Dragging a session that's already alone in its window is now a no-op (previously duplicated windows exponentially — 2, 4, 8...).

## Approach

Mirrors Ghostty's own `SurfaceScrollView`/`SurfaceRepresentable` architecture:

1. **`GhosttyHostViewContainer`** — thin NSView wrapper returned by `makeNSView`. SwiftUI manages the container lifecycle; the actual `GhosttyHostView` (with running Ghostty process) lives as a child and survives container destruction via the ViewModel cache.

2. **AppKit window creation** — `handleDragToNewWindow` now creates the new window via `NSWindow` + `NSHostingController` with a pre-configured ViewModel (`preloadForTransfer`), instead of `NSApp.sendAction(newWindowForTab)`. The host view is in the new ViewModel BEFORE the source split tree is modified — no orphan gap.

3. **Solo session guard** — early return in `handlePaneDragToNewWindow` when `!isInSplitMode`.

## Test plan

- [ ] Create a split (2+ panes), drag one pane outside — should open in new window with session continuing uninterrupted
- [ ] Verify the Claude session in the dragged pane is NOT restarted (check conversation continues)
- [ ] Verify the remaining pane in the source window continues working
- [ ] Drag a solo session (no split) outside — should be a no-op (no new window created)
- [ ] Repeat drag-outside on a solo session multiple times — should not duplicate windows
- [ ] Normal split operations (split right/down, close pane) still work correctly
- [ ] File drag-and-drop into terminal still works in both single and split mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)