### PR TITLE
refactor: session ID architecture cleanup

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -19,7 +19,7 @@
 - [project_inspector_panel.md](project_inspector_panel.md) — Right-side inspector panel: branch switcher, paths, .inspector() modifier, GitBranchService extensions
 - [project_file_drop.md](project_file_drop.md) — File drag & drop: dual-path (AppKit split / SwiftUI single-pane), header highlight, focus-on-drop
 - [project_ide_detection.md](project_ide_detection.md) — IDE detection via NSWorkspace bundle IDs, IDEHeaderButton in pane header, supported IDEs
-- [project_session_store.md](project_session_store.md) — GRDB-backed SQLite DB for persistent sessions, TENVY_TERMINAL_ID mapping, write discipline
+- [project_session_store.md](project_session_store.md) — GRDB-backed SQLite DB for persistent sessions, TENVY_SESSION_ID mapping, write discipline
 - [project_permission_config.md](project_permission_config.md) — Two-level permission management, shared PermissionEditorView, --settings CLI flag
 
 ## Feedback

--- a/.claude/memory/architecture.md
+++ b/.claude/memory/architecture.md
@@ -22,7 +22,7 @@ Fork session: `claude --resume <session-id> --fork-session` — creates new sess
 
 ## GhosttyHostView Cache
 
-SwiftUI destroys NSViewRepresentable views when they move in the view tree (e.g., single → split). `ContentViewModel` holds `[String: GhosttyHostView]` cache keyed by `terminalId`. Cached views bypass `setup()` — process survives restructuring.
+SwiftUI destroys NSViewRepresentable views when they move in the view tree (e.g., single → split). `ContentViewModel` holds `[String: GhosttyHostView]` cache keyed by `tenvySessionId`. Cached views bypass `setup()` — process survives restructuring.
 
 ## Preview Infrastructure
 

--- a/.claude/memory/project_new_session_dialog.md
+++ b/.claude/memory/project_new_session_dialog.md
@@ -12,7 +12,7 @@ A unified modal dialog that replaces the old `WorktreeSplitView` and `NoGitSplit
 
 1. **"+" button** (new session): `SessionListView` → folder picker → `ContentViewModel.createNewSession(_:)` → sets `pendingSplit` with `isNewSessionFlow: true`
 2. **Context menu split**: `TerminalAction.splitRequested` → `ContentViewModel.handleSplitRequested(direction:)` → sets `pendingSplit` with `isNewSessionFlow: false`
-3. **Plain terminal split**: Same as #2, but detected via `isPlainTerminal(terminalId)` → sets `isPlainTerminalSplit: true`, skips git entirely
+3. **Plain terminal split**: Same as #2, but detected via `isPlainTerminal(tenvySessionId)` → sets `isPlainTerminalSplit: true`, skips git entirely
 
 ## Data Models
 

--- a/.claude/memory/project_permission_config.md
+++ b/.claude/memory/project_permission_config.md
@@ -14,7 +14,7 @@ Two-level permission management for Claude Code sessions.
 
 **Change detection**: Uses SHA-256 hash (`ClaudePermissionSettings.contentHash` via CryptoKit, sorted-keys JSON encoding). Inspector compares `sessionPermissions.contentHash` against `launchedPermissionsHash` from DB. Restart button appears only when hashes differ; reverting changes hides it.
 
-**Restart flow**: Confirmation dialog first. Then `ContentViewModel.restartSessionWithNewPermissions()` kills process, evicts GhosttyHostView cache, bumps `terminalViewGenerations` counter. The counter change updates `.id()` on the terminal view, forcing SwiftUI to destroy and recreate the NSViewRepresentable (triggering fresh `makeNSView`). Inspector observes `restartGeneration` and re-reads hash from DB.
+**Restart flow**: Confirmation dialog first. Then `ContentViewModel.restartSessionWithNewPermissions()` kills process, evicts GhosttyHostView cache, and assigns a new `ghosttyInstanceId` on `SessionRuntimeInfo`. The instance ID change updates `.id()` on the terminal view, forcing SwiftUI to destroy and recreate the NSViewRepresentable (triggering fresh `makeNSView`). Inspector re-reads hash from DB after restart.
 
 **Shared UI**: `PermissionEditorView` takes `Binding<ClaudePermissionSettings>`. Used in both Settings (global, writes to file) and Inspector (per-session, writes to DB). Includes mode picker, preset toggles, allow/deny/ask rule lists, raw JSON editor sheet.
 

--- a/.claude/memory/project_session_drag_drop.md
+++ b/.claude/memory/project_session_drag_drop.md
@@ -12,7 +12,7 @@ Pane headers (not sidebar) provide drag-and-drop for rearranging split panes and
 
 ### Drag Source: `PaneHeaderDragSourceNSView`
 
-AppKit `NSDraggingSource` covering the entire header bar. Encodes `terminalId` (String) on the pasteboard using `com.tenvy.paneId` UTType. Creates a 20%-scaled terminal snapshot as drag preview.
+AppKit `NSDraggingSource` covering the entire header bar. Encodes `tenvySessionId` (String) on the pasteboard using `com.tenvy.paneId` UTType. Creates a 20%-scaled terminal snapshot as drag preview.
 
 - Escape key cancels the drag
 - Open/closed hand cursor during hover/drag
@@ -39,7 +39,7 @@ Sessions move between windows without restarting the terminal process:
 
 ### Drag Outside Window
 
-`ContentViewModel` observes `paneDragEndedNoTarget` notification. When a pane header is dragged outside all windows, `handlePaneDragToNewWindow` finds the session by terminalId and calls `handleDragToNewWindow` to open it in a new tab.
+`ContentViewModel` observes `paneDragEndedNoTarget` notification. When a pane header is dragged outside all windows, `handlePaneDragToNewWindow` finds the session by tenvySessionId and calls `handleDragToNewWindow` to open it in a new tab.
 
 ### SessionListAction Enum
 

--- a/.claude/memory/project_session_store.md
+++ b/.claude/memory/project_session_store.md
@@ -8,14 +8,14 @@ Sessions are stored in `~/Library/Application Support/Tenvy/sessions.sqlite` via
 
 ## Architecture
 
-- **SessionRecord** (GRDB model): `terminalId` (PK), `claudeSessionId`, `workingDirectory`, `projectPath`, `title`, `hookState`, `currentTool`, `branchName`, `worktreePath`, `isPlainTerminal`, `isActive`, etc.
+- **SessionRecord** (GRDB model): `tenvySessionId` (PK), `claudeSessionId`, `workingDirectory`, `projectPath`, `title`, `hookState`, `currentTool`, `branchName`, `worktreePath`, `isPlainTerminal`, `isActive`, etc.
 - **SessionStore**: sole DB write service. Views never call it — only ViewModels and services do.
 - **@Query**: views observe the DB via GRDBQuery's `@Query` property wrapper for reactive updates.
 - **SessionRuntimeInfo**: stays in-memory for CPU/memory/PID (too chatty for DB).
 
 ## Session ID Mapping
 
-`TENVY_TERMINAL_ID` env var is set before launching Claude. The hook script includes it as `terminal_id` in JSONL events. When `HookEventService` receives an event with both `session_id` and `terminal_id`, `SessionStore.updateHookState()` writes the mapping to DB.
+`TENVY_SESSION_ID` env var is set before launching Claude. The hook script includes it as `terminal_id` in JSONL events. When `HookEventService` receives an event with both `session_id` and `terminal_id`, `SessionStore.updateHookState()` writes the mapping to DB.
 
 **Why:** Replaces the old fragile `syncNewSessionWithDiscoveredSession()` / `syncSplitSession()` which matched by `workingDirectory` + `lastModified` — caused cross-pane state leakage and plain terminals stealing Claude session IDs.
 
@@ -30,7 +30,7 @@ Sessions are stored in `~/Library/Application Support/Tenvy/sessions.sqlite` via
 - `Tenvy/Core/AppDatabase.swift` — DatabasePool, migrations
 - `Tenvy/Core/SessionRecord.swift` — model + query request types
 - `Tenvy/Core/SessionStore.swift` — write service
-- `Tenvy/Features/Terminal/TerminalEnvironment.swift` — sets `TENVY_TERMINAL_ID`
+- `Tenvy/Features/Terminal/TerminalEnvironment.swift` — sets `TENVY_SESSION_ID`
 - `Hooks/chat-sessions-hook.sh` — includes `terminal_id` in events
 
 **How to apply:** When adding new session state that should be persistent and observable across views, add a column to `SessionRecord` (with migration), a write method to `SessionStore`, and use `@Query` in views. Keep ephemeral per-process data (CPU, PID) in `SessionRuntimeInfo`.

--- a/.claude/memory/project_split_panes.md
+++ b/.claude/memory/project_split_panes.md
@@ -43,7 +43,7 @@ This sets `focused = false` on every new surface. Focus is granted only via `mak
 
 **Problem:** SwiftUI destroys+recreates `NSViewRepresentable`-backed views when they move to a different structural position in the view tree (e.g. single-pane → first split). This kills the Ghostty process.
 
-**Fix:** `ContentViewModel` holds a strong `@ObservationIgnored private var ghosttyHostViews: [String: GhosttyHostView]` cache keyed by `session.terminalId`.
+**Fix:** `ContentViewModel` holds a strong `@ObservationIgnored private var ghosttyHostViews: [String: GhosttyHostView]` cache keyed by `session.tenvySessionId`.
 
 - `GhosttyTerminalView` takes `existingHostView: GhosttyHostView?` and `onHostViewCreated: ((GhosttyHostView) -> Void)?`.
 - `makeNSView` returns the cached view unchanged if `existingHostView != nil` (skips `setup()`, process never restarts).
@@ -55,7 +55,7 @@ This sets `focused = false` on every new surface. Focus is granted only via `mak
 
 Every pane has a `PaneHeaderView` (always visible, single or split mode): 30px height, title left, IDE button + close button right. Files are in `Tenvy/Features/Terminal/PaneHeader/` folder (split from the original monolithic file).
 
-**Drag**: `PaneHeaderDragSourceNSView` (in `PaneHeaderDragSource.swift`, AppKit NSDraggingSource) encodes `terminalId` on pasteboard as `com.tenvy.paneId` UTType. 20%-scaled terminal snapshot as drag image. Follows Ghostty's `SurfaceDragSourceView` pattern. Trailing inset is dynamic — expands when IDE button is present to pass through clicks to SwiftUI.
+**Drag**: `PaneHeaderDragSourceNSView` (in `PaneHeaderDragSource.swift`, AppKit NSDraggingSource) encodes `tenvySessionId` on pasteboard as `com.tenvy.paneId` UTType. 20%-scaled terminal snapshot as drag image. Follows Ghostty's `SurfaceDragSourceView` pattern. Trailing inset is dynamic — expands when IDE button is present to pass through clicks to SwiftUI.
 
 **Drop**: `PaneDropDelegate` (SwiftUI DropDelegate) on each `PaneLeafView`. `PaneDropZone` (ported from Ghostty's `TerminalSplitDropZone`) determines split direction via triangular edge detection.
 
@@ -63,4 +63,4 @@ Every pane has a `PaneHeaderView` (always visible, single or split mode): 30px h
 
 **Title**: Claude sessions → `session.title`; plain terminals → `GhosttyEmbedSurface.title` (auto-updates from escape sequences).
 
-**Cross-window**: Pasteboard uses string terminalId. `Notification.paneDragEndedNoTarget` posted when drag ends outside windows — ready for future cross-window transfer.
+**Cross-window**: Pasteboard uses string tenvySessionId. `Notification.paneDragEndedNoTarget` posted when drag ends outside windows — ready for future cross-window transfer.

--- a/.claude/memory/project_terminal_env.md
+++ b/.claude/memory/project_terminal_env.md
@@ -12,7 +12,7 @@ zsh -l -c '<init-script>; exec /path/to/claude [args]'
 
 **Shell Init Script**: Configurable in Settings → Shell Init Script using CodeEditor (bash syntax highlighting). Default: `[ -f "$HOME/.zshrc" ] && source "$HOME/.zshrc" 2>/dev/null;`. Stored in `AppSettings.shellInitScript` (UserDefaults key `settings.shellInitScript`).
 
-**Per-split override**: The unified NewSessionDialogView has a "Shell Init Script" tab allowing per-session init script customization. Overrides are stored in `ContentViewModel.splitInitScripts` (keyed by terminalId) and consumed on first terminal launch.
+**Per-split override**: The unified NewSessionDialogView has a "Shell Init Script" tab allowing per-session init script customization. Overrides are stored in `ContentViewModel.splitInitScripts` (keyed by tenvySessionId) and consumed on first terminal launch.
 
 **`TerminalEnvironment.shellArgs()` and `.plainShellArgs()`**: Both accept optional `initScript:` parameter. Falls back to global `AppSettings.shared.shellInitScript` when nil.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,9 @@ Sessions are stored in a local SQLite database at `~/Library/Application Support
 
 **Architecture**: `SessionStore` is the sole service that writes to the DB. Views never write directly — they observe via GRDBQuery's `@Query` property wrapper and emit actions to ViewModels/services.
 
-**Session ID mapping**: When Claude is launched from Tenvy, the `TENVY_TERMINAL_ID` env var is set to the session's `terminalId`. The hook script includes this in JSONL events as `terminal_id`. When the first hook event arrives with both `session_id` (Claude's) and `terminal_id` (ours), `SessionStore.updateHookState()` writes the mapping to DB — instant, reliable sync with no heuristic matching.
+**Session ID mapping**: When Claude is launched from Tenvy, the `TENVY_SESSION_ID` env var is set to the session's `tenvySessionId`. The hook script includes this in JSONL events as `terminal_id`. When the first hook event arrives with both `session_id` (Claude's) and `terminal_id` (ours), `SessionStore.mapClaudeSessionId()` writes the mapping to DB — instant, reliable sync with no heuristic matching.
 
-**What's in the DB**: Session identity (`terminalId`, `claudeSessionId`), paths (`workingDirectory`, `projectPath`), display state (`title`, `hookState`, `currentTool`), metadata (`branchName`, `worktreePath`, `isPlainTerminal`, `isActive`).
+**What's in the DB**: Session identity (`tenvySessionId`, `claudeSessionId`), paths (`workingDirectory`, `projectPath`), display state (`title`, `hookState`, `currentTool`), metadata (`branchName`, `worktreePath`, `isPlainTerminal`, `isActive`).
 
 **What stays in-memory**: CPU/memory/PID metrics (`SessionRuntimeInfo`) — changes every 500ms, meaningless after restart.
 
@@ -234,7 +234,7 @@ Registered events and their state mappings:
 
 **Key**: `PermissionRequest` is the correct hook for actual permission dialogs. `Notification` is a generic event that fires for multiple types — always check `notification_type`.
 
-**Terminal ID mapping**: Each hook event includes `terminal_id` (from `TENVY_TERMINAL_ID` env var). This enables instant, reliable mapping of Claude's `session_id` to Tenvy's `terminalId` — no heuristic matching needed. Events from sessions not launched by Tenvy have `terminal_id: null`.
+**Session ID mapping**: Each hook event includes `terminal_id` (from `TENVY_SESSION_ID` env var). This enables instant, reliable mapping of Claude's `session_id` to Tenvy's `tenvySessionId` — no heuristic matching needed. Events from sessions not launched by Tenvy have `terminal_id: null`.
 
 ### Notifications
 
@@ -300,7 +300,7 @@ Ghostty's `SurfaceView` defaults `focused = true`. This breaks `performKeyEquiva
 
 #### GhosttyHostView Cache (process survival across split transitions)
 
-SwiftUI destroys and recreates `NSViewRepresentable`-backed views when they move to a different structural position in the view tree (e.g. single-pane → split). This kills the Ghostty process. Fix: `ContentViewModel` holds a strong `[String: GhosttyHostView]` cache keyed by `session.terminalId`.
+SwiftUI destroys and recreates `NSViewRepresentable`-backed views when they move to a different structural position in the view tree (e.g. single-pane → split). This kills the Ghostty process. Fix: `ContentViewModel` holds a strong `[String: GhosttyHostView]` cache keyed by `session.tenvySessionId`.
 
 - `@ObservationIgnored private var ghosttyHostViews: [String: GhosttyHostView]` — strong refs, invisible to SwiftUI observation.
 - `GhosttyTerminalView.makeNSView`: returns cached view if `existingHostView != nil`, skipping `setup()` (no new process).
@@ -313,7 +313,7 @@ SwiftUI destroys and recreates `NSViewRepresentable`-backed views when they move
 
 Every pane (single or split) has a `PaneHeaderView` at the top: 30px height, session title left-aligned, close button right-aligned. The header is the drag source for rearranging panes.
 
-**Drag source**: `PaneHeaderDragSourceNSView` (AppKit `NSDraggingSource`) — follows Ghostty's `SurfaceDragSourceView` pattern. Encodes the pane's `terminalId` (String) on the pasteboard using custom type `com.tenvy.paneId` (registered as `UTType` in `Info.plist`). Creates a 20%-scaled terminal snapshot as the drag preview image. Escape key cancels the drag.
+**Drag source**: `PaneHeaderDragSourceNSView` (AppKit `NSDraggingSource`) — follows Ghostty's `SurfaceDragSourceView` pattern. Encodes the pane's `tenvySessionId` (String) on the pasteboard using custom type `com.tenvy.paneId` (registered as `UTType` in `Info.plist`). Creates a 20%-scaled terminal snapshot as the drag preview image. Escape key cancels the drag.
 
 **Drop target**: `PaneDropDelegate` (SwiftUI `DropDelegate`) on each `PaneLeafView`. Uses `PaneDropZone` (ported from Ghostty's `TerminalSplitDropZone`) for triangular edge detection — the cursor's nearest edge determines the split direction (top/bottom/left/right). A colored overlay shows where the split will appear.
 
@@ -359,7 +359,7 @@ Two-level permission management: global (App Settings) and per-session (Inspecto
 
 **Launch integration**: `ClaudeSessionTerminalView.makeNSView()` reads permission settings from DB and passes `--permission-mode`, `--allowedTools`, and `--disallowedTools` CLI flags. CLI flags are additive, so tools the user removed from the inherited allow list are automatically passed as `--disallowedTools` (deny overrides allow in Claude Code). The launched-with state is recorded as a SHA-256 hash in `SessionRecord.launchedPermissionsHash`.
 
-**Live changes**: Per-session permission edits are saved to DB immediately but don't take effect on the running CLI until restart. Inspector shows a warning on first edit and a "Restart with New Permissions" button when `sessionPermissions.contentHash != launchedPermissionsHash`. Restart shows a confirmation dialog, then kills the process, evicts the cached GhosttyHostView, and bumps `terminalViewGenerations` to force SwiftUI to recreate the terminal (triggering a fresh `makeNSView`).
+**Live changes**: Per-session permission edits are saved to DB immediately but don't take effect on the running CLI until restart. Inspector shows a warning on first edit and a "Restart with New Permissions" button when `sessionPermissions.contentHash != launchedPermissionsHash`. Restart shows a confirmation dialog, then kills the process, evicts the cached GhosttyHostView, and resets `SessionRuntimeInfo` (which regenerates `ghosttyInstanceId`, changing the view's `.id()` to force SwiftUI to recreate the terminal via a fresh `makeNSView`). The Inspector observes the session record reactively via `@Query` — when the launched permissions hash updates in DB after restart, the restart button disappears automatically.
 
 **Shared UI**: `PermissionEditorView` is used by both Settings (global) and Inspector (per-session). Takes `Binding<ClaudePermissionSettings>`. Includes mode picker, preset toggles, allow/deny/ask rule lists, and raw JSON editor sheet.
 

--- a/Hooks/chat-sessions-hook.sh
+++ b/Hooks/chat-sessions-hook.sh
@@ -22,7 +22,7 @@ NOTIFICATION_MESSAGE=$(echo "$INPUT" | jq -r '.message // empty')
 TOOL_INPUT=$(echo "$INPUT" | jq -c '.tool_input // null')
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Terminal ID from Tenvy — enables reliable session ID mapping
-TERMINAL_ID="${TENVY_TERMINAL_ID:-}"
+TERMINAL_ID="${TENVY_SESSION_ID:-}"
 
 # Skip if no session ID
 if [ -z "$SESSION_ID" ]; then

--- a/Tenvy/App/ContentView.swift
+++ b/Tenvy/App/ContentView.swift
@@ -99,7 +99,6 @@ struct ContentView: View {
         InspectorPanelView(
           session: session,
           runtimeInfo: viewModel.runtimeState.info(for: session.id),
-          restartGeneration: viewModel.terminalViewGenerations[session.terminalId, default: 0],
           onAction: { action in
             viewModel.handleInspectorAction(action, for: session)
           }
@@ -313,14 +312,14 @@ private struct DetailView<Key: PreferenceKey>: View where Key.Value == CGRect {
         // from reaching GhosttyHostView. Use SwiftUI .onDrop as fallback,
         // applied after .allowsHitTesting() to avoid being blocked.
         PaneLeafView(session: session, viewModel: viewModel, isSplitPane: false)
-          .id(session.terminalId)
+          .id(session.tenvySessionId)
           .opacity(viewModel.isTerminalVisible ? 1 : 0)
           .allowsHitTesting(viewModel.isTerminalVisible)
           .onDrop(of: [.fileURL], isTargeted: $isSinglePaneDropTargeted) { providers in
-            viewModel.handleSinglePaneFileDrop(providers: providers, terminalId: session.terminalId)
+            viewModel.handleSinglePaneFileDrop(providers: providers, tenvySessionId: session.tenvySessionId)
           }
           .onChange(of: isSinglePaneDropTargeted) { _, targeted in
-            viewModel.fileDropTargetTerminalId = targeted ? session.terminalId : nil
+            viewModel.fileDropTargetTerminalId = targeted ? session.tenvySessionId : nil
           }
           .background(terminalFrameReader(visible: viewModel.isTerminalVisible))
           .padding(16)
@@ -405,28 +404,28 @@ private struct PaneLeafView: View {
   var isSplitPane: Bool = false
 
   /// DB-backed session record — provides hookState from the persistent store.
-  @Query<SessionByTerminalIdRequest> private var sessionRecord: SessionRecord?
+  @Query<SessionByTenvyIdRequest> private var sessionRecord: SessionRecord?
   @State private var dropZone: PaneDropZone?
 
   init(session: ClaudeSession, viewModel: ContentViewModel, isSplitPane: Bool = false) {
     self.session = session
     self.viewModel = viewModel
     self.isSplitPane = isSplitPane
-    _sessionRecord = Query(SessionByTerminalIdRequest(terminalId: session.terminalId))
+    _sessionRecord = Query(SessionByTenvyIdRequest(tenvySessionId: session.tenvySessionId))
   }
 
   private var isClaudeSession: Bool {
-    !viewModel.isPlainTerminal(session.terminalId)
+    !viewModel.isPlainTerminal(session.tenvySessionId)
   }
 
   private var isFileDropTargeted: Bool {
-    viewModel.fileDropTargetTerminalId == session.terminalId
+    viewModel.fileDropTargetTerminalId == session.tenvySessionId
   }
 
   /// Reactive title: prefers DB record, falls back to session manager, then session struct.
   private var paneTitle: String {
-    if viewModel.isPlainTerminal(session.terminalId) {
-      return viewModel.plainTerminalTitles[session.terminalId] ?? "Terminal"
+    if viewModel.isPlainTerminal(session.tenvySessionId) {
+      return viewModel.plainTerminalTitles[session.tenvySessionId] ?? "Terminal"
     }
     if let dbTitle = sessionRecord?.title, dbTitle != "New Session" {
       return dbTitle
@@ -442,7 +441,7 @@ private struct PaneLeafView: View {
       VStack(spacing: 0) {
         PaneHeaderView(
           title: paneTitle,
-          terminalId: session.terminalId,
+          tenvySessionId: session.tenvySessionId,
           isSelected: viewModel.selectedSession?.id == session.id,
           isFileDropTarget: isFileDropTargeted,
           runtimeInfo: viewModel.runtimeState.info(for: session.id),
@@ -451,12 +450,12 @@ private struct PaneLeafView: View {
           ideResult: isClaudeSession ? viewModel.ideDetectionResult(for: session) : nil,
           projectPath: isClaudeSession ? (session.workingDirectory.isEmpty ? session.projectPath : session.workingDirectory) : nil,
           snapshotProvider: { [weak viewModel] in
-            viewModel?.ghosttyHostView(for: session.terminalId)?.snapshotImage
+            viewModel?.ghosttyHostView(for: session.tenvySessionId)?.snapshotImage
           },
           onAction: { action in
             switch action {
             case .closeRequested:
-              viewModel.closePaneByTerminalId(session.terminalId)
+              viewModel.closePaneByTerminalId(session.tenvySessionId)
             }
           }
         )
@@ -471,7 +470,7 @@ private struct PaneLeafView: View {
         }
       }
       .onDrop(of: [.tenvyPaneId], delegate: PaneDropDelegate(
-        destinationTerminalId: session.terminalId,
+        destinationTerminalId: session.tenvySessionId,
         dropZone: $dropZone,
         viewSize: geometry.size,
         headerHeight: 30,
@@ -483,14 +482,14 @@ private struct PaneLeafView: View {
   private func handleAction(_ action: TerminalAction) {
     switch action {
     case .fileDragEntered:
-      viewModel.fileDropTargetTerminalId = session.terminalId
+      viewModel.fileDropTargetTerminalId = session.tenvySessionId
     case .fileDragExited:
-      if viewModel.fileDropTargetTerminalId == session.terminalId {
+      if viewModel.fileDropTargetTerminalId == session.tenvySessionId {
         viewModel.fileDropTargetTerminalId = nil
       }
     case .fileDropped:
       viewModel.fileDropTargetTerminalId = nil
-      viewModel.focusPane(terminalId: session.terminalId)
+      viewModel.focusPane(tenvySessionId: session.tenvySessionId)
     default:
       if isSplitPane {
         viewModel.handleSplitTerminalAction(action, for: session)
@@ -502,31 +501,31 @@ private struct PaneLeafView: View {
 
   @ViewBuilder
   private var terminalView: some View {
-    if viewModel.isPlainTerminal(session.terminalId) {
+    if viewModel.isPlainTerminal(session.tenvySessionId) {
       PlainTerminalView(
         workingDirectory: session.workingDirectory,
         isSelected: viewModel.selectedSession?.id == session.id,
-        initScript: viewModel.initScript(for: session.terminalId),
+        initScript: viewModel.initScript(for: session.tenvySessionId),
         onAction: { action in
           handleAction(action)
         },
-        existingHostView: viewModel.ghosttyHostView(for: session.terminalId),
-        onHostViewCreated: { viewModel.cacheGhosttyHostView($0, terminalId: session.terminalId) }
+        existingHostView: viewModel.ghosttyHostView(for: session.tenvySessionId),
+        onHostViewCreated: { viewModel.cacheGhosttyHostView($0, tenvySessionId: session.tenvySessionId) }
       )
-      .id(viewModel.terminalViewId(for: session.terminalId))
+      .id(viewModel.runtimeState.info(for: session.id).ghosttyInstanceId)
     } else {
       ClaudeSessionTerminalView(
         session: session,
         isSelected: viewModel.selectedSession?.id == session.id,
-        forkSourceSessionId: viewModel.forkSourceSessionId(for: session.terminalId),
-        initScript: viewModel.initScript(for: session.terminalId),
+        forkSourceSessionId: viewModel.forkSourceSessionId(for: session.tenvySessionId),
+        initScript: viewModel.initScript(for: session.tenvySessionId),
         onAction: { action in
           handleAction(action)
         },
-        existingHostView: viewModel.ghosttyHostView(for: session.terminalId),
-        onHostViewCreated: { viewModel.cacheGhosttyHostView($0, terminalId: session.terminalId) }
+        existingHostView: viewModel.ghosttyHostView(for: session.tenvySessionId),
+        onHostViewCreated: { viewModel.cacheGhosttyHostView($0, tenvySessionId: session.tenvySessionId) }
       )
-      .id(viewModel.terminalViewId(for: session.terminalId))
+      .id(viewModel.runtimeState.info(for: session.id).ghosttyInstanceId)
     }
   }
 }

--- a/Tenvy/App/ContentViewModel.swift
+++ b/Tenvy/App/ContentViewModel.swift
@@ -66,7 +66,7 @@ struct WorktreeSplitFormData {
 
   /// Pre-generated unique session ID. Used in custom worktree paths
   /// so the path includes a unique identifier before the session is created.
-  let uniqueSessionId: String = UUID().uuidString
+  let tenvySessionId: String = UUID().uuidString
 
   /// Whether to run `git init` (only relevant when hasGitRepo == false)
   var initGit: Bool = false
@@ -102,10 +102,6 @@ final class ContentViewModel {
   @ObservationIgnored
   private var ghosttyHostViews: [String: GhosttyHostView] = [:]
 
-  /// Generation counter per terminal — incremented on restart to force SwiftUI to
-  /// destroy and recreate the NSViewRepresentable (triggering a fresh `makeNSView`).
-  private(set) var terminalViewGenerations: [String: Int] = [:]
-
   /// Currently selected diff file (for diff viewer)
   var selectedDiffFile: GitChangedFile?
 
@@ -140,7 +136,7 @@ final class ContentViewModel {
   var sessionToRename: ClaudeSession?
   var renameText: String = ""
 
-  /// Maps terminalId → source session ID for fork launches.
+  /// Maps tenvySessionId → source session ID for fork launches.
   @ObservationIgnored
   private var pendingForkSessions: [String: String] = [:]
 
@@ -156,7 +152,7 @@ final class ContentViewModel {
   @ObservationIgnored
   private var titleCancellables: [String: AnyCancellable] = [:]
 
-  /// Per-terminal init script overrides (keyed by terminalId). Consumed on first access.
+  /// Per-terminal init script overrides (keyed by tenvySessionId). Consumed on first access.
   @ObservationIgnored
   private var splitInitScripts: [String: String] = [:]
 
@@ -181,9 +177,9 @@ final class ContentViewModel {
       queue: .main
     ) { [weak self] notification in
       guard let self,
-            let terminalId = notification.userInfo?[Notification.paneDragTerminalIdKey] as? String,
-            self.ownsTerminal(terminalId) else { return }
-      self.handlePaneDragToNewWindow(terminalId: terminalId)
+            let tenvySessionId = notification.userInfo?[Notification.paneDragTenvySessionIdKey] as? String,
+            self.ownsTerminal(tenvySessionId) else { return }
+      self.handlePaneDragToNewWindow(tenvySessionId: tenvySessionId)
     }
   }
 
@@ -195,34 +191,26 @@ final class ContentViewModel {
 
   // MARK: - GhosttyHostView Cache
 
-  /// Returns the cached GhosttyHostView for the given terminal identity, if any.
-  /// Returns a stable view identity string for the terminal. Includes a generation
-  /// counter that increments on restart, forcing SwiftUI to recreate the NSViewRepresentable.
-  func terminalViewId(for terminalId: String) -> String {
-    let gen = terminalViewGenerations[terminalId, default: 0]
-    return gen == 0 ? terminalId : "\(terminalId)-\(gen)"
-  }
-
   /// Also checks AppModel's transfer store for cross-window moves.
-  func ghosttyHostView(for terminalId: String) -> GhosttyHostView? {
-    if let view = ghosttyHostViews[terminalId] { return view }
+  func ghosttyHostView(for tenvySessionId: String) -> GhosttyHostView? {
+    if let view = ghosttyHostViews[tenvySessionId] { return view }
     // Auto-pickup from cross-window transfer
-    if let view = appModel.pickupTransfer(terminalId: terminalId) {
-      ghosttyHostViews[terminalId] = view
+    if let view = appModel.pickupTransfer(tenvySessionId: tenvySessionId) {
+      ghosttyHostViews[tenvySessionId] = view
       return view
     }
     return nil
   }
 
   /// Stores a newly created GhosttyHostView so it survives view-tree restructuring.
-  func cacheGhosttyHostView(_ view: GhosttyHostView, terminalId: String) {
-    ghosttyHostViews[terminalId] = view
+  func cacheGhosttyHostView(_ view: GhosttyHostView, tenvySessionId: String) {
+    ghosttyHostViews[tenvySessionId] = view
     // Subscribe to surface title changes for plain terminals
-    if isPlainTerminal(terminalId), let surface = view.surface {
-      titleCancellables[terminalId] = surface.titlePublisher
+    if isPlainTerminal(tenvySessionId), let surface = view.surface {
+      titleCancellables[tenvySessionId] = surface.titlePublisher
         .receive(on: DispatchQueue.main)
         .sink { [weak self] newTitle in
-          self?.plainTerminalTitles[terminalId] = newTitle.isEmpty ? "Terminal" : newTitle
+          self?.plainTerminalTitles[tenvySessionId] = newTitle.isEmpty ? "Terminal" : newTitle
         }
     }
   }
@@ -232,10 +220,10 @@ final class ContentViewModel {
   /// (so Ghostty's C layer stops accessing it), but the host view is kept alive until
   /// the next run-loop tick so `ghostty_surface_free` completes before the `SurfaceView`
   /// deallocates — otherwise the C-layer userdata pointer dangles (BAD_ACCESS).
-  func evictGhosttyHostView(terminalId: String) {
-    guard let hostView = ghosttyHostViews.removeValue(forKey: terminalId) else { return }
-    titleCancellables.removeValue(forKey: terminalId)
-    plainTerminalTitles.removeValue(forKey: terminalId)
+  func evictGhosttyHostView(tenvySessionId: String) {
+    guard let hostView = ghosttyHostViews.removeValue(forKey: tenvySessionId) else { return }
+    titleCancellables.removeValue(forKey: tenvySessionId)
+    plainTerminalTitles.removeValue(forKey: tenvySessionId)
     hostView.close()
     DispatchQueue.main.async { [hostView] in _ = hostView }
   }
@@ -330,7 +318,7 @@ final class ContentViewModel {
     }
 
     // Open in this window (no session yet)
-    // Use activated session if available (preserves terminalId for synced sessions)
+    // Use activated session if available (preserves tenvySessionId for synced sessions)
     let sessionToSelect = appModel.activatedSessions[session.id] ?? session
     clearDetailSelection()
     setSelectedSession(sessionToSelect)
@@ -354,9 +342,9 @@ final class ContentViewModel {
 
   // MARK: - Drag & Drop Transfer
 
-  /// Whether this ViewModel owns a terminal with the given terminalId.
-  func ownsTerminal(_ terminalId: String) -> Bool {
-    ghosttyHostViews[terminalId] != nil
+  /// Whether this ViewModel owns a terminal with the given tenvySessionId.
+  func ownsTerminal(_ tenvySessionId: String) -> Bool {
+    ghosttyHostViews[tenvySessionId] != nil
   }
 
   /// Whether this ViewModel owns the given session (for cross-window transfer).
@@ -381,8 +369,8 @@ final class ContentViewModel {
     guard let session else { return }
 
     // Extract host view WITHOUT closing — deposit for the destination to pick up
-    if let hostView = ghosttyHostViews.removeValue(forKey: session.terminalId) {
-      appModel.depositForTransfer(terminalId: session.terminalId, hostView: hostView)
+    if let hostView = ghosttyHostViews.removeValue(forKey: session.tenvySessionId) {
+      appModel.depositForTransfer(tenvySessionId: session.tenvySessionId, hostView: hostView)
     }
 
     // Remove from this window's structure (without deactivating — session stays alive)
@@ -426,14 +414,14 @@ final class ContentViewModel {
   /// Receive a transferred session and insert it alongside an existing session.
   /// Called directly (same window) or via AppModel (cross-window).
   func receiveTransferredSession(_ session: ClaudeSession, alongside targetSessionId: String, direction: SplitDirection = .right) {
-    if let hostView = appModel.pickupTransfer(terminalId: session.terminalId) {
-      ghosttyHostViews[session.terminalId] = hostView
+    if let hostView = appModel.pickupTransfer(tenvySessionId: session.tenvySessionId) {
+      ghosttyHostViews[session.tenvySessionId] = hostView
       // Re-subscribe to title updates for plain terminals
-      if plainTerminalIds.contains(session.terminalId), let surface = hostView.surface {
-        titleCancellables[session.terminalId] = surface.titlePublisher
+      if plainTerminalIds.contains(session.tenvySessionId), let surface = hostView.surface {
+        titleCancellables[session.tenvySessionId] = surface.titlePublisher
           .receive(on: DispatchQueue.main)
           .sink { [weak self] newTitle in
-            self?.plainTerminalTitles[session.terminalId] = newTitle.isEmpty ? "Terminal" : newTitle
+            self?.plainTerminalTitles[session.tenvySessionId] = newTitle.isEmpty ? "Terminal" : newTitle
           }
       }
     }
@@ -442,9 +430,9 @@ final class ContentViewModel {
   }
 
   /// Handle a pane header dragged outside any window — open in a new window.
-  private func handlePaneDragToNewWindow(terminalId: String) {
-    // Find the session by terminalId
-    guard let session = findSessionByTerminalId(terminalId) else { return }
+  private func handlePaneDragToNewWindow(tenvySessionId: String) {
+    // Find the session by tenvySessionId
+    guard let session = findSessionByTerminalId(tenvySessionId) else { return }
 
     // If this session is already alone in its window (no split), dragging outside is a no-op.
     // The session is already in a dedicated window — nothing to detach from.
@@ -455,13 +443,13 @@ final class ContentViewModel {
     handleDragToNewWindow(sessionId: session.id)
   }
 
-  /// Find a session by terminalId, searching local state and activated sessions.
-  private func findSessionByTerminalId(_ terminalId: String) -> ClaudeSession? {
-    if let tree = splitTree, let s = tree.allSessions.first(where: { $0.terminalId == terminalId }) {
+  /// Find a session by tenvySessionId, searching local state and activated sessions.
+  private func findSessionByTerminalId(_ tenvySessionId: String) -> ClaudeSession? {
+    if let tree = splitTree, let s = tree.allSessions.first(where: { $0.tenvySessionId == tenvySessionId }) {
       return s
     }
-    if selectedSession?.terminalId == terminalId { return selectedSession }
-    return appModel.activatedSessions.values.first(where: { $0.terminalId == terminalId })
+    if selectedSession?.tenvySessionId == tenvySessionId { return selectedSession }
+    return appModel.activatedSessions.values.first(where: { $0.tenvySessionId == tenvySessionId })
   }
 
   /// Handle a session dragged to the "New Window" drop zone.
@@ -477,11 +465,11 @@ final class ContentViewModel {
     guard let session = appModel.activatedSessions[sessionId] else { return }
 
     // 1. Extract host view from source cache (without modifying split tree yet)
-    let hostView = ghosttyHostViews.removeValue(forKey: session.terminalId)
+    let hostView = ghosttyHostViews.removeValue(forKey: session.tenvySessionId)
 
     // 2. Create new ViewModel pre-loaded with session and host view
     let newVM = ContentViewModel(appModel: appModel)
-    newVM.preloadForTransfer(session: session, hostView: hostView, isPlainTerminal: isPlainTerminal(session.terminalId))
+    newVM.preloadForTransfer(session: session, hostView: hostView, isPlainTerminal: isPlainTerminal(session.tenvySessionId))
 
     // 3. Create new window using AppKit (like Ghostty's TerminalController.newWindow)
     let rootView = ContentView(viewModel: newVM)
@@ -520,15 +508,15 @@ final class ContentViewModel {
     selectedSession = session
     appModel.activateSession(session)
     if let hostView {
-      ghosttyHostViews[session.terminalId] = hostView
+      ghosttyHostViews[session.tenvySessionId] = hostView
     }
     if isPlainTerminal {
-      plainTerminalIds.insert(session.terminalId)
+      plainTerminalIds.insert(session.tenvySessionId)
       if let surface = hostView?.surface {
-        titleCancellables[session.terminalId] = surface.titlePublisher
+        titleCancellables[session.tenvySessionId] = surface.titlePublisher
           .receive(on: DispatchQueue.main)
           .sink { [weak self] newTitle in
-            self?.plainTerminalTitles[session.terminalId] = newTitle.isEmpty ? "Terminal" : newTitle
+            self?.plainTerminalTitles[session.tenvySessionId] = newTitle.isEmpty ? "Terminal" : newTitle
           }
       }
     }
@@ -606,7 +594,7 @@ final class ContentViewModel {
         hasSubmodules: WorktreeService.hasSubmodules(repoRoot: repoRoot)
       )
       worktreeSplitForm = form
-      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: repoRoot, branchName: defaultBranchName, sessionId: form.uniqueSessionId)
+      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: repoRoot, branchName: defaultBranchName, sessionId: form.tenvySessionId)
       return
     }
 
@@ -636,7 +624,7 @@ final class ContentViewModel {
       hasSubmodules: false
     )
     worktreeSplitForm = form2
-    worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: workDir, branchName: defaultBranchName, sessionId: form2.uniqueSessionId)
+    worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: workDir, branchName: defaultBranchName, sessionId: form2.tenvySessionId)
   }
 
   /// Activates a new session in the current window or a new tab.
@@ -666,7 +654,7 @@ final class ContentViewModel {
     guard let focused = selectedSession ?? primarySession else { return }
 
     // Plain terminal splits skip the git dialog — just show shell init script
-    if isPlainTerminal(focused.terminalId) {
+    if isPlainTerminal(focused.tenvySessionId) {
       pendingSplit = PendingSplitRequest(
         direction: direction,
         sourceSession: focused,
@@ -717,7 +705,7 @@ final class ContentViewModel {
         hasSubmodules: WorktreeService.hasSubmodules(repoRoot: repoRoot)
       )
       worktreeSplitForm = splitForm
-      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: repoRoot, branchName: defaultBranchName, sessionId: splitForm.uniqueSessionId)
+      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: repoRoot, branchName: defaultBranchName, sessionId: splitForm.tenvySessionId)
     } else {
       // No git repo — still populate form for the unified dialog
       let workDir = focused.workingDirectory
@@ -738,7 +726,7 @@ final class ContentViewModel {
         hasSubmodules: false
       )
       worktreeSplitForm = splitForm2
-      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: workDir, branchName: defaultBranchName, sessionId: splitForm2.uniqueSessionId)
+      worktreeSplitForm?.worktreePath = WorktreeService.defaultWorktreePath(repoRoot: workDir, branchName: defaultBranchName, sessionId: splitForm2.tenvySessionId)
     }
   }
 
@@ -757,7 +745,7 @@ final class ContentViewModel {
     if !hasGitRepo && !form.initGit {
       let session = pending.sourceSession
       insertSessionRecord(session: session)
-      splitInitScripts[session.terminalId] = form.initScript
+      splitInitScripts[session.tenvySessionId] = form.initScript
       dismissSplitDialog()
       if pending.isNewSessionFlow {
         activateNewSession(session)
@@ -769,7 +757,7 @@ final class ContentViewModel {
     if hasGitRepo && !needsBranch && !needsWorktree {
       let session = pending.sourceSession
       insertSessionRecord(session: session, branchName: form.baseBranch)
-      splitInitScripts[session.terminalId] = form.initScript
+      splitInitScripts[session.tenvySessionId] = form.initScript
       dismissSplitDialog()
       if pending.isNewSessionFlow {
         activateNewSession(session)
@@ -791,7 +779,7 @@ final class ContentViewModel {
           isCreatingWorktree = false
           let session = pending.sourceSession
           insertSessionRecord(session: session)
-          splitInitScripts[session.terminalId] = form.initScript
+          splitInitScripts[session.tenvySessionId] = form.initScript
           dismissSplitDialog()
           if pending.isNewSessionFlow {
             activateNewSession(session)
@@ -847,10 +835,10 @@ final class ContentViewModel {
             lastModified: Date(),
             filePath: nil,
             isNewSession: true,
-            terminalId: form.uniqueSessionId
+            tenvySessionId: form.tenvySessionId
           )
           insertSessionRecord(session: newSession, branchName: form.newBranchName, worktreePath: form.worktreePath)
-          splitInitScripts[newSession.terminalId] = form.initScript
+          splitInitScripts[newSession.tenvySessionId] = form.initScript
           dismissSplitDialog()
           activateNewSession(newSession)
         } else {
@@ -862,7 +850,7 @@ final class ContentViewModel {
             forkSession: form.forkSession,
             sourceSession: pending.sourceSession,
             initScript: form.initScript,
-            terminalId: form.uniqueSessionId
+            tenvySessionId: form.tenvySessionId
           )
           dismissSplitDialog()
         }
@@ -897,7 +885,7 @@ final class ContentViewModel {
         isCreatingWorktree = false
         let session = pending.sourceSession
         insertSessionRecord(session: session, branchName: form.newBranchName)
-        splitInitScripts[session.terminalId] = form.initScript
+        splitInitScripts[session.tenvySessionId] = form.initScript
         dismissSplitDialog()
         if pending.isNewSessionFlow {
           activateNewSession(session)
@@ -928,9 +916,9 @@ final class ContentViewModel {
           isNewSession: true
         )
         insertSessionRecord(session: newSession, isPlainTerminal: true)
-        plainTerminalIds.insert(newSession.terminalId)
+        plainTerminalIds.insert(newSession.tenvySessionId)
         if let initScript {
-          splitInitScripts[newSession.terminalId] = initScript
+          splitInitScripts[newSession.tenvySessionId] = initScript
         }
         dismissSplitDialog()
         activateNewSession(newSession)
@@ -939,7 +927,7 @@ final class ContentViewModel {
         let session = pending.sourceSession
         insertSessionRecord(session: session)
         if let initScript {
-          splitInitScripts[session.terminalId] = initScript
+          splitInitScripts[session.tenvySessionId] = initScript
         }
         dismissSplitDialog()
         activateNewSession(session)
@@ -958,9 +946,9 @@ final class ContentViewModel {
       isNewSession: true
     )
     insertSessionRecord(session: newSession, isPlainTerminal: true)
-    plainTerminalIds.insert(newSession.terminalId)
+    plainTerminalIds.insert(newSession.tenvySessionId)
     if let initScript {
-      splitInitScripts[newSession.terminalId] = initScript
+      splitInitScripts[newSession.tenvySessionId] = initScript
     }
     appModel.activateSession(newSession)
     insertSplitPane(newSession, at: pending.sourceSession.id, direction: pending.direction)
@@ -973,19 +961,19 @@ final class ContentViewModel {
   }
 
   /// Whether a given terminal should launch as a plain shell (no claude).
-  func isPlainTerminal(_ terminalId: String) -> Bool {
-    plainTerminalIds.contains(terminalId)
+  func isPlainTerminal(_ tenvySessionId: String) -> Bool {
+    plainTerminalIds.contains(tenvySessionId)
   }
 
 
   /// Returns and consumes the source session ID for fork, if applicable.
-  func forkSourceSessionId(for terminalId: String) -> String? {
-    pendingForkSessions.removeValue(forKey: terminalId)
+  func forkSourceSessionId(for tenvySessionId: String) -> String? {
+    pendingForkSessions.removeValue(forKey: tenvySessionId)
   }
 
   /// Returns and consumes the per-split init script override, if any.
-  func initScript(for terminalId: String) -> String? {
-    splitInitScripts.removeValue(forKey: terminalId)
+  func initScript(for tenvySessionId: String) -> String? {
+    splitInitScripts.removeValue(forKey: tenvySessionId)
   }
 
   // MARK: - Worktree Split Helpers
@@ -998,7 +986,7 @@ final class ContentViewModel {
     forkSession: Bool,
     sourceSession: ClaudeSession,
     initScript: String? = nil,
-    terminalId: String? = nil
+    tenvySessionId: String? = nil
   ) {
     let newSession = ClaudeSession(
       id: UUID().uuidString,
@@ -1008,7 +996,7 @@ final class ContentViewModel {
       lastModified: Date(),
       filePath: nil,
       isNewSession: !forkSession,
-      terminalId: terminalId
+      tenvySessionId: tenvySessionId
     )
     insertSessionRecord(
       session: newSession,
@@ -1017,10 +1005,10 @@ final class ContentViewModel {
       forkSourceSessionId: forkSession ? sourceSession.id : nil
     )
     if forkSession {
-      pendingForkSessions[newSession.terminalId] = sourceSession.id
+      pendingForkSessions[newSession.tenvySessionId] = sourceSession.id
     }
     if let initScript {
-      splitInitScripts[newSession.terminalId] = initScript
+      splitInitScripts[newSession.tenvySessionId] = initScript
     }
     appModel.activateSession(newSession)
     insertSplitPane(newSession, at: sourceSession.id, direction: direction)
@@ -1041,7 +1029,7 @@ final class ContentViewModel {
       : ClaudeSettingsService.mergeForNewSession(projectPath: session.projectPath)
 
     let record = SessionRecord(
-      terminalId: session.terminalId,
+      tenvySessionId: session.tenvySessionId,
       workingDirectory: session.workingDirectory,
       projectPath: session.projectPath,
       title: session.title,
@@ -1135,8 +1123,8 @@ final class ContentViewModel {
   /// Close a specific split pane by session ID.
   func closeSplitPane(id: String) {
     // Evict cached host view so its process terminates.
-    if let terminalId = splitTree?.allSessions.first(where: { $0.id == id })?.terminalId {
-      evictGhosttyHostView(terminalId: terminalId)
+    if let tenvySessionId = splitTree?.allSessions.first(where: { $0.id == id })?.tenvySessionId {
+      evictGhosttyHostView(tenvySessionId: tenvySessionId)
     }
     appModel.deactivateSession(id)
     appModel.terminalInput.unregister(sessionId: id)
@@ -1181,10 +1169,10 @@ final class ContentViewModel {
     } else {
       return
     }
-    guard let destSession = localSessions.first(where: { $0.terminalId == destinationTerminalId }) else { return }
+    guard let destSession = localSessions.first(where: { $0.tenvySessionId == destinationTerminalId }) else { return }
 
     // Check if source is in this window
-    if let sourceSession = localSessions.first(where: { $0.terminalId == sourceTerminalId }) {
+    if let sourceSession = localSessions.first(where: { $0.tenvySessionId == sourceTerminalId }) {
       // Same-window move within split tree
       guard let tree = splitTree else { return }
       guard let newTree = tree.moving(sessionId: sourceSession.id, toDestination: destSession.id, direction: direction) else {
@@ -1201,7 +1189,7 @@ final class ContentViewModel {
       }
     } else {
       // Cross-window: source is in another window
-      guard let sourceSession = appModel.activatedSessions.values.first(where: { $0.terminalId == sourceTerminalId }) else { return }
+      guard let sourceSession = appModel.activatedSessions.values.first(where: { $0.tenvySessionId == sourceTerminalId }) else { return }
 
       // Release from source window (deposits host view on AppModel)
       appModel.releaseSessionForTransfer(sessionId: sourceSession.id)
@@ -1211,12 +1199,12 @@ final class ContentViewModel {
     }
   }
 
-  /// Close a pane identified by terminalId (called from the pane header close button).
-  func closePaneByTerminalId(_ terminalId: String) {
+  /// Close a pane identified by tenvySessionId (called from the pane header close button).
+  func closePaneByTerminalId(_ tenvySessionId: String) {
     let session: ClaudeSession?
     if let tree = splitTree {
-      session = tree.allSessions.first(where: { $0.terminalId == terminalId })
-    } else if selectedSession?.terminalId == terminalId {
+      session = tree.allSessions.first(where: { $0.tenvySessionId == tenvySessionId })
+    } else if selectedSession?.tenvySessionId == tenvySessionId {
       session = selectedSession
     } else {
       session = nil
@@ -1230,7 +1218,7 @@ final class ContentViewModel {
     let primary = primarySession
     if let tree = splitTree {
       for session in tree.allSessions where session.id != primary?.id {
-        evictGhosttyHostView(terminalId: session.terminalId)
+        evictGhosttyHostView(tenvySessionId: session.tenvySessionId)
         appModel.deactivateSession(session.id)
         appModel.terminalInput.unregister(sessionId: session.id)
       }
@@ -1278,10 +1266,10 @@ final class ContentViewModel {
     }
 
     // Evict the cached host view and bump the generation counter.
-    // The generation change updates the `.id()` on the terminal view, forcing SwiftUI
+    // Evict the cached host view and reset runtime info. The `reset()` call regenerates
+    // `ghosttyInstanceId`, which changes the `.id()` on the terminal view, forcing SwiftUI
     // to destroy the old NSViewRepresentable and create a fresh one (calling `makeNSView`).
-    evictGhosttyHostView(terminalId: session.terminalId)
-    terminalViewGenerations[session.terminalId, default: 0] += 1
+    evictGhosttyHostView(tenvySessionId: session.tenvySessionId)
     runtimeInfo.reset()
   }
 
@@ -1322,9 +1310,9 @@ final class ContentViewModel {
       sessionToRename = nil
       return
     }
-    if isPlainTerminal(session.terminalId) {
+    if isPlainTerminal(session.tenvySessionId) {
       // Plain terminal: set the Ghostty surface title directly
-      ghosttyHostViews[session.terminalId]?.surface?.rename(to: renameText)
+      ghosttyHostViews[session.tenvySessionId]?.surface?.rename(to: renameText)
     } else {
       // Claude session: update the JSONL file on disk
       do {
@@ -1344,18 +1332,18 @@ final class ContentViewModel {
   var fileDropTargetTerminalId: String?
 
   /// Focuses the pane with the given terminal ID — used when files are dropped on a non-focused pane.
-  func focusPane(terminalId: String) {
-    guard let session = findSessionByTerminalId(terminalId),
-          selectedSession?.terminalId != terminalId else { return }
+  func focusPane(tenvySessionId: String) {
+    guard let session = findSessionByTerminalId(tenvySessionId),
+          selectedSession?.tenvySessionId != tenvySessionId else { return }
     selectedSession = session
-    ghosttyHostView(for: terminalId)?.makeFocused()
+    ghosttyHostView(for: tenvySessionId)?.makeFocused()
   }
 
   /// Handles file drop in single-pane mode (SwiftUI fallback).
   /// GhosttyHostView's AppKit drag handler doesn't fire in single-pane because
   /// SwiftUI's hosting layer intercepts drags before they reach child NSViews.
-  func handleSinglePaneFileDrop(providers: [NSItemProvider], terminalId: String) -> Bool {
-    guard let hostView = ghosttyHostView(for: terminalId) else { return false }
+  func handleSinglePaneFileDrop(providers: [NSItemProvider], tenvySessionId: String) -> Bool {
+    guard let hostView = ghosttyHostView(for: tenvySessionId) else { return false }
 
     let group = DispatchGroup()
     var urls: [URL] = []
@@ -1395,7 +1383,7 @@ final class ContentViewModel {
   /// For active Claude sessions, shows a confirmation alert before terminating.
   /// For plain terminals or split panes, closes directly.
   private func handleCloseRequested(for session: ClaudeSession) {
-    let isPlain = isPlainTerminal(session.terminalId)
+    let isPlain = isPlainTerminal(session.tenvySessionId)
     let runtimeInfo = runtimeState.info(for: session.id)
     let isActive = !isPlain && runtimeInfo.state != .inactive
 
@@ -1423,7 +1411,7 @@ final class ContentViewModel {
       closeSplitPane(id: session.id)
     } else {
       // Single terminal — deactivate and clear selection
-      evictGhosttyHostView(terminalId: session.terminalId)
+      evictGhosttyHostView(tenvySessionId: session.tenvySessionId)
       appModel.deactivateSession(session.id)
       appModel.terminalInput.unregister(sessionId: session.id)
       runtimeInfo.reset()
@@ -1444,15 +1432,15 @@ final class ContentViewModel {
   }
 
   /// Hook-event-driven session sync — replaces the old heuristic matching.
-  /// Called by AppModel when a hook event arrives with both `terminalId` and `claudeSessionId`.
-  /// Finds the session with the matching `terminalId` (which uses a temp UUID as its `id`)
+  /// Called by AppModel when a hook event arrives with both `tenvySessionId` and `claudeSessionId`.
+  /// Finds the session with the matching `tenvySessionId` (which uses a temp UUID as its `id`)
   /// and swaps its `id` to the real Claude session ID. The terminal continues running
-  /// without interruption because `terminalId` (SwiftUI view identity) stays the same.
-  func syncSessionFromHookEvent(terminalId: String, claudeSessionId: String) {
+  /// without interruption because `tenvySessionId` (SwiftUI view identity) stays the same.
+  func syncSessionFromHookEvent(tenvySessionId: String, claudeSessionId: String) {
     // Skip plain terminals — they don't have Claude sessions
-    guard !isPlainTerminal(terminalId) else { return }
+    guard !isPlainTerminal(tenvySessionId) else { return }
 
-    // Find the session with this terminalId — check selected, split tree, or primary
+    // Find the session with this tenvySessionId — check selected, split tree, or primary
     let allSessions: [ClaudeSession] = {
       var sessions = [ClaudeSession]()
       if let sel = selectedSession { sessions.append(sel) }
@@ -1460,11 +1448,11 @@ final class ContentViewModel {
       return sessions
     }()
 
-    guard let current = allSessions.first(where: { $0.terminalId == terminalId }),
+    guard let current = allSessions.first(where: { $0.tenvySessionId == tenvySessionId }),
           current.isNewSession,
           current.id != claudeSessionId else { return }
 
-    // Create synced session with Claude's real ID but same terminalId
+    // Create synced session with Claude's real ID but same tenvySessionId
     let synced = ClaudeSession(
       id: claudeSessionId,
       title: current.title,
@@ -1473,7 +1461,7 @@ final class ContentViewModel {
       lastModified: Date(),
       filePath: current.filePath,
       isNewSession: false,
-      terminalId: current.terminalId
+      tenvySessionId: current.tenvySessionId
     )
 
     // Transfer runtime state (CPU/PID) from temp ID to real ID

--- a/Tenvy/Core/AppDatabase.swift
+++ b/Tenvy/Core/AppDatabase.swift
@@ -81,7 +81,7 @@ struct AppDatabase {
 
     migrator.registerMigration("v1_createSessionRecord") { db in
       try db.create(table: "sessionRecord") { t in
-        t.primaryKey("terminalId", .text)
+        t.primaryKey("tenvySessionId", .text)
         t.column("claudeSessionId", .text)
         t.column("workingDirectory", .text).notNull()
         t.column("projectPath", .text).notNull()
@@ -104,6 +104,10 @@ struct AppDatabase {
         t.add(column: "permissionSettings", .text)
         t.add(column: "launchedPermissionsHash", .text)
       }
+    }
+
+    migrator.registerMigration("v3_renameTerminalIdToTenvySessionId") { db in
+      try db.execute(sql: "ALTER TABLE sessionRecord RENAME COLUMN terminalId TO tenvySessionId")
     }
 
     return migrator

--- a/Tenvy/Core/AppModel.swift
+++ b/Tenvy/Core/AppModel.swift
@@ -89,13 +89,13 @@ final class AppModel {
   }
 
   /// Deposit a host view for cross-window transfer (source calls this).
-  func depositForTransfer(terminalId: String, hostView: GhosttyHostView) {
-    hostViewTransfers[terminalId] = hostView
+  func depositForTransfer(tenvySessionId: String, hostView: GhosttyHostView) {
+    hostViewTransfers[tenvySessionId] = hostView
   }
 
   /// Pick up a transferred host view (destination calls this). Removes from store.
-  func pickupTransfer(terminalId: String) -> GhosttyHostView? {
-    hostViewTransfers.removeValue(forKey: terminalId)
+  func pickupTransfer(tenvySessionId: String) -> GhosttyHostView? {
+    hostViewTransfers.removeValue(forKey: tenvySessionId)
   }
 
   /// Ask whichever ViewModel owns this session to release it for transfer.
@@ -122,17 +122,17 @@ final class AppModel {
   }
 
   /// Notify all ViewModels about a hook-event-driven session sync.
-  /// Called when a hook event arrives with both `terminalId` and `claudeSessionId`.
-  func syncSessionFromHookEvent(terminalId: String, claudeSessionId: String) {
+  /// Called when a hook event arrives with both `tenvySessionId` and `claudeSessionId`.
+  func syncSessionFromHookEvent(tenvySessionId: String, claudeSessionId: String) {
     registeredViewModels.removeAll { $0.value == nil }
     for ref in registeredViewModels {
-      ref.value?.syncSessionFromHookEvent(terminalId: terminalId, claudeSessionId: claudeSessionId)
+      ref.value?.syncSessionFromHookEvent(tenvySessionId: tenvySessionId, claudeSessionId: claudeSessionId)
     }
   }
 
   // MARK: - Session models (observable list of facades)
 
-  /// Stable `ClaudeSessionModel` instances keyed by `terminalId` — allows the
+  /// Stable `ClaudeSessionModel` instances keyed by `tenvySessionId` — allows the
   /// computed `sessionModels` to return the same object for the same session
   /// across re-evaluations, preserving SwiftUI view identity.
   private var sessionModelCache: [String: ClaudeSessionModel] = [:]
@@ -143,18 +143,18 @@ final class AppModel {
   var sessionModels: [ClaudeSessionModel] {
     let current = sessionDiscovery.sessions
     // Evict stale cache entries for sessions that no longer exist
-    let currentTerminalIds = Set(current.map { $0.terminalId })
-    for key in sessionModelCache.keys where !currentTerminalIds.contains(key) {
+    let currentTenvyIds = Set(current.map { $0.tenvySessionId })
+    for key in sessionModelCache.keys where !currentTenvyIds.contains(key) {
       sessionModelCache.removeValue(forKey: key)
     }
     return current.map { session in
-      if let cached = sessionModelCache[session.terminalId] {
+      if let cached = sessionModelCache[session.tenvySessionId] {
         // Refresh immutable facts (title, lastModified, etc.) without recreating the object
         cached.updateSession(session)
         return cached
       }
       let model = ClaudeSessionModel(session: session, runtime: runtimeRegistry.info(for: session.id))
-      sessionModelCache[session.terminalId] = model
+      sessionModelCache[session.tenvySessionId] = model
       return model
     }
   }
@@ -244,12 +244,12 @@ final class AppModel {
   /// Remove a session from the activated set (terminal closed or session terminated).
   /// Also resets the runtime info so the sidebar no longer shows stale CPU/MEM/PID data.
   func deactivateSession(_ sessionId: String) {
-    // Find the terminalId for DB update — check activated sessions first
-    let terminalId = activatedSessions[sessionId]?.terminalId ?? sessionId
-    try? sessionStore.deactivateSession(terminalId: terminalId)
+    // Find the tenvySessionId for DB update — check activated sessions first
+    let tenvySessionId = activatedSessions[sessionId]?.tenvySessionId ?? sessionId
+    try? sessionStore.deactivateSession(tenvySessionId: tenvySessionId)
 
     // Clean up per-session settings file
-    SessionSettingsFileManager.removeSettingsFile(terminalId: terminalId)
+    SessionSettingsFileManager.removeSettingsFile(tenvySessionId: tenvySessionId)
 
     activatedSessions.removeValue(forKey: sessionId)
     runtimeRegistry.info(for: sessionId).reset()
@@ -311,26 +311,26 @@ final class AppModel {
   }
 
   private func wireCallbacks() {
-    hookMonitor.onStateChange = { [weak self] sessionId, hookState, tool, message, eventTime, terminalId in
+    hookMonitor.onStateChange = { [weak self] sessionId, hookState, tool, message, eventTime, tenvySessionId in
       Task { @MainActor in
         guard let self else { return }
 
         // Sync FIRST: swap temp UUID → real Claude session ID if needed.
         // This ensures runtimeRegistry and notifications use the correct ID.
-        if let terminalId {
-          self.syncSessionFromHookEvent(terminalId: terminalId, claudeSessionId: sessionId)
+        if let tenvySessionId {
+          self.syncSessionFromHookEvent(tenvySessionId: tenvySessionId, claudeSessionId: sessionId)
         }
 
         // Now update in-memory runtime state — after sync, session.id matches sessionId
         self.runtimeRegistry.updateHookState(for: sessionId, state: hookState, tool: tool, eventTime: eventTime)
         self.hookSetup.receivedHookEvent(for: sessionId)
 
-        // Map claudeSessionId → terminalId in DB (one-time per session).
+        // Map claudeSessionId → tenvySessionId in DB (one-time per session).
         // Hook state is kept in-memory only (runtimeRegistry) — writing it to DB
         // on every event caused a cascade of @Query refetches that saturated I/O.
-        if let terminalId {
+        if let tenvySessionId {
           try? self.sessionStore.mapClaudeSessionId(
-            terminalId: terminalId,
+            tenvySessionId: tenvySessionId,
             claudeSessionId: sessionId
           )
         }

--- a/Tenvy/Core/ClaudeSessionModel.swift
+++ b/Tenvy/Core/ClaudeSessionModel.swift
@@ -53,10 +53,10 @@ final class ClaudeSessionModel: Identifiable {
 
   // MARK: - Identifiable
 
-  /// Stable identifier for SwiftUI — uses `terminalId` so list selection and view
+  /// Stable identifier for SwiftUI — uses `tenvySessionId` so list selection and view
   /// identity survive the temp-to-real session ID sync (the ID that changes is
-  /// `session.id`; `terminalId` is invariant across the sync).
-  var id: String { session.terminalId }
+  /// `session.id`; `tenvySessionId` is invariant across the sync).
+  var id: String { session.tenvySessionId }
 
   // MARK: - Forwarded session properties
 
@@ -92,7 +92,7 @@ final class ClaudeSessionModel: Identifiable {
 
   /// Replace the underlying `ClaudeSession` value.
   /// Called during the temp-to-real ID sync when Claude creates the actual JSONL file.
-  /// The `terminalId` (and therefore this object's `id`) stays the same, so SwiftUI
+  /// The `tenvySessionId` (and therefore this object's `id`) stays the same, so SwiftUI
   /// does not recreate any views that hold a reference to this model.
   func updateSession(_ newSession: ClaudeSession) {
     session = newSession

--- a/Tenvy/Core/Protocols/HookMonitoring.swift
+++ b/Tenvy/Core/Protocols/HookMonitoring.swift
@@ -26,7 +26,7 @@ import Foundation
 @MainActor
 protocol HookMonitoring: AnyObject {
   /// Callback fired when a session's state changes.
-  /// Parameters: (sessionId, hookState, tool, permissionMessage, eventTimestamp, terminalId)
+  /// Parameters: (sessionId, hookState, tool, permissionMessage, eventTimestamp, tenvySessionId)
   var onStateChange: ((String, HookState, String?, String?, Date?, String?) -> Void)? { get set }
 
   /// Open the events file and start watching for new lines

--- a/Tenvy/Core/SessionRecord.swift
+++ b/Tenvy/Core/SessionRecord.swift
@@ -27,10 +27,10 @@ import GRDB
 /// This is the source of truth for session identity, paths, and hook state.
 /// Views observe these records via `@Query`; writes go through `SessionStore`.
 struct SessionRecord: Codable, FetchableRecord, PersistableRecord, Identifiable {
-  var id: String { terminalId }
+  var id: String { tenvySessionId }
 
-  /// Stable terminal identifier — primary key, set at creation, never changes.
-  let terminalId: String
+  /// Stable Tenvy session identifier — primary key, generated at creation, never changes.
+  let tenvySessionId: String
 
   /// Claude CLI's own session ID. Set when the first hook event arrives
   /// carrying both `session_id` and `terminal_id`, providing instant reliable mapping.
@@ -134,14 +134,14 @@ struct ActiveSessionsRequest: ValueObservationQueryable {
   }
 }
 
-/// Fetches a single session record by terminal ID.
-struct SessionByTerminalIdRequest: ValueObservationQueryable {
+/// Fetches a single session record by Tenvy session ID.
+struct SessionByTenvyIdRequest: ValueObservationQueryable {
   static var defaultValue: SessionRecord? { nil }
 
-  let terminalId: String
+  let tenvySessionId: String
 
   func fetch(_ db: Database) throws -> SessionRecord? {
-    try SessionRecord.fetchOne(db, key: terminalId)
+    try SessionRecord.fetchOne(db, key: tenvySessionId)
   }
 }
 

--- a/Tenvy/Core/SessionStore.swift
+++ b/Tenvy/Core/SessionStore.swift
@@ -49,9 +49,9 @@ final class SessionStore: Sendable {
   /// Map a Claude session ID to a terminal ID (one-time per session).
   /// Skips the write if the mapping is already set — avoids triggering
   /// GRDB @Query observers on every hook event.
-  func mapClaudeSessionId(terminalId: String, claudeSessionId: String) throws {
+  func mapClaudeSessionId(tenvySessionId: String, claudeSessionId: String) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         guard record.claudeSessionId != claudeSessionId else { return }
         record.claudeSessionId = claudeSessionId
         record.lastModifiedAt = Date()
@@ -63,9 +63,9 @@ final class SessionStore: Sendable {
   // MARK: - Lifecycle
 
   /// Mark a session as inactive. Called when the terminal is closed.
-  func deactivateSession(terminalId: String) throws {
+  func deactivateSession(tenvySessionId: String) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.isActive = false
         record.hookState = nil
         record.currentTool = nil
@@ -76,9 +76,9 @@ final class SessionStore: Sendable {
   }
 
   /// Delete a session record entirely.
-  func deleteSession(terminalId: String) throws {
+  func deleteSession(tenvySessionId: String) throws {
     try writer.write { db in
-      _ = try SessionRecord.deleteOne(db, key: terminalId)
+      _ = try SessionRecord.deleteOne(db, key: tenvySessionId)
     }
   }
 
@@ -86,7 +86,7 @@ final class SessionStore: Sendable {
 
   /// Upsert session metadata discovered from a `.jsonl` file.
   /// Called by SessionManager after scanning Claude's session files.
-  /// Does NOT overwrite `terminalId` if a record already exists for this Claude session ID.
+  /// Does NOT overwrite `tenvySessionId` if a record already exists for this Claude session ID.
   func upsertFromSessionFile(
     claudeSessionId: String,
     title: String,
@@ -104,16 +104,16 @@ final class SessionStore: Sendable {
         guard existing.title != title
                 || existing.sessionFilePath != filePath
                 || existing.lastModifiedAt != lastModified else { return }
-        // Update only discoverable fields — don't touch terminalId or paths
+        // Update only discoverable fields — don't touch tenvySessionId or paths
         existing.title = title
         existing.sessionFilePath = filePath
         existing.lastModifiedAt = lastModified
         try existing.update(db)
       } else {
         // New session discovered from file (not created in app) —
-        // use claudeSessionId as terminalId since there's no Tenvy terminal for it
+        // use claudeSessionId as tenvySessionId since there's no Tenvy terminal for it
         let record = SessionRecord(
-          terminalId: claudeSessionId,
+          tenvySessionId: claudeSessionId,
           claudeSessionId: claudeSessionId,
           workingDirectory: workingDirectory,
           projectPath: projectPath,
@@ -132,9 +132,9 @@ final class SessionStore: Sendable {
   // MARK: - Title Updates
 
   /// Update the title for a session. Called after renaming.
-  func updateTitle(terminalId: String, title: String) throws {
+  func updateTitle(tenvySessionId: String, title: String) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.title = title
         record.lastModifiedAt = Date()
         try record.update(db)
@@ -145,9 +145,9 @@ final class SessionStore: Sendable {
   // MARK: - Git Branch
 
   /// Update the git branch for a session.
-  func updateBranch(terminalId: String, branchName: String?) throws {
+  func updateBranch(tenvySessionId: String, branchName: String?) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.branchName = branchName
         record.lastModifiedAt = Date()
         try record.update(db)
@@ -158,9 +158,9 @@ final class SessionStore: Sendable {
   // MARK: - Permission Settings
 
   /// Update permission settings for a session.
-  func updatePermissionSettings(terminalId: String, settings: ClaudePermissionSettings) throws {
+  func updatePermissionSettings(tenvySessionId: String, settings: ClaudePermissionSettings) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.permissionSettings = SessionRecord.encode(settings)
         record.lastModifiedAt = Date()
         try record.update(db)
@@ -169,9 +169,9 @@ final class SessionStore: Sendable {
   }
 
   /// Reset permission settings to nil (re-inherit from global + project on next launch).
-  func resetPermissionSettings(terminalId: String) throws {
+  func resetPermissionSettings(tenvySessionId: String) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.permissionSettings = nil
         record.launchedPermissionsHash = nil
         record.lastModifiedAt = Date()
@@ -181,9 +181,9 @@ final class SessionStore: Sendable {
   }
 
   /// Update the launched permissions hash after a session starts or restarts.
-  func updateLaunchedPermissionsHash(terminalId: String, hash: String) throws {
+  func updateLaunchedPermissionsHash(tenvySessionId: String, hash: String) throws {
     try writer.write { db in
-      if var record = try SessionRecord.fetchOne(db, key: terminalId) {
+      if var record = try SessionRecord.fetchOne(db, key: tenvySessionId) {
         record.launchedPermissionsHash = hash
         record.lastModifiedAt = Date()
         try record.update(db)

--- a/Tenvy/Features/Git/NewSessionDialogView.swift
+++ b/Tenvy/Features/Git/NewSessionDialogView.swift
@@ -305,7 +305,7 @@ struct NewSessionDialogView: View {
           // Auto-update worktree path when branch name changes (only in worktree mode)
           if form.wrappedValue.gitMode == .worktree, let formData = viewModel.worktreeSplitForm {
             viewModel.worktreeSplitForm?.worktreePath =
-              WorktreeService.defaultWorktreePath(repoRoot: formData.repoRoot, branchName: newName, sessionId: formData.uniqueSessionId)
+              WorktreeService.defaultWorktreePath(repoRoot: formData.repoRoot, branchName: newName, sessionId: formData.tenvySessionId)
           }
         }
     }

--- a/Tenvy/Features/Inspector/InspectorPanelView.swift
+++ b/Tenvy/Features/Inspector/InspectorPanelView.swift
@@ -22,9 +22,9 @@
 
 import SwiftUI
 import GRDB
+import GRDBQuery
 
 /// Right-side inspector panel showing details about the focused session or terminal.
-/// Available only in DEBUG builds.
 struct InspectorPanelView: View {
 
   /// Actions emitted by the inspector for the parent to handle.
@@ -35,23 +35,38 @@ struct InspectorPanelView: View {
 
   let session: ClaudeSession
   let runtimeInfo: SessionRuntimeInfo
-  /// Incremented by the parent when the session is restarted (e.g. with new permissions).
-  /// Observed to reload the launched-with snapshot so the restart button disappears.
-  var restartGeneration: Int = 0
   var onAction: (Action) -> Void = { _ in }
 
   @Environment(AppModel.self) private var appModel
+
+  /// Reactively observes the session record in DB — permission hash changes
+  /// (e.g. after restart) are picked up automatically without generation counters.
+  @Query<SessionByTenvyIdRequest> private var sessionRecord: SessionRecord?
+
   @State private var availableBranches: [String] = []
   @State private var branchError: String?
   @State private var showBranchError = false
   @State private var sessionPermissions = ClaudePermissionSettings.empty
-  /// SHA-256 hash of the permissions when the session was last launched.
-  /// Read from DB; compared against `sessionPermissions.contentHash` to detect changes.
-  @State private var launchedPermissionsHash = ""
   @State private var permissionsLoaded = false
   @State private var showPermissionRestartWarning = false
   @State private var showRestartConfirmation = false
-  @State private var isPlainTerminal = false
+
+  init(session: ClaudeSession, runtimeInfo: SessionRuntimeInfo, onAction: @escaping (Action) -> Void = { _ in }) {
+    self.session = session
+    self.runtimeInfo = runtimeInfo
+    self.onAction = onAction
+    _sessionRecord = Query(SessionByTenvyIdRequest(tenvySessionId: session.tenvySessionId))
+  }
+
+  /// Whether this is a plain terminal (from DB record).
+  private var isPlainTerminal: Bool {
+    sessionRecord?.isPlainTerminal ?? false
+  }
+
+  /// SHA-256 hash of the permissions when the session was last launched.
+  private var launchedPermissionsHash: String {
+    sessionRecord?.launchedPermissionsHash ?? ""
+  }
 
   /// True when the current permissions differ from what the session launched with.
   private var permissionSettingsModified: Bool {
@@ -78,15 +93,9 @@ struct InspectorPanelView: View {
       loadBranches()
       loadPermissions()
     }
-    .onChange(of: restartGeneration) { _, _ in
-      // After restart, re-read the launched hash from DB.
-      // makeNSView() writes the hash when it launches with the current permissions,
-      // so the hash now matches sessionPermissions.contentHash → button disappears.
-      if let record = try? AppDatabase.shared.databaseReader.read({ db in
-        try SessionRecord.fetchOne(db, key: session.terminalId)
-      }) {
-        launchedPermissionsHash = record.launchedPermissionsHash ?? ""
-      }
+    .onChange(of: sessionRecord?.launchedPermissionsHash) { _, _ in
+      // DB record updated (e.g. after restart) — hide the restart warning
+      // since launchedPermissionsHash now matches the current permissions.
       showPermissionRestartWarning = false
     }
     .onChange(of: sessionPermissions) { _, newValue in
@@ -203,19 +212,10 @@ struct InspectorPanelView: View {
   private func loadPermissions() {
     permissionsLoaded = false
 
-    if let record = try? AppDatabase.shared.databaseReader.read({ db in
-      try SessionRecord.fetchOne(db, key: session.terminalId)
-    }) {
-      isPlainTerminal = record.isPlainTerminal
-      launchedPermissionsHash = record.launchedPermissionsHash ?? ""
-      if let stored = record.decodedPermissionSettings {
-        sessionPermissions = stored
-      } else {
-        sessionPermissions = ClaudeSettingsService.mergeForNewSession(projectPath: session.projectPath)
-      }
+    if let record = sessionRecord,
+       let stored = record.decodedPermissionSettings {
+      sessionPermissions = stored
     } else {
-      isPlainTerminal = false
-      launchedPermissionsHash = ""
       sessionPermissions = ClaudeSettingsService.mergeForNewSession(projectPath: session.projectPath)
     }
 
@@ -225,7 +225,7 @@ struct InspectorPanelView: View {
 
   private func savePermissions(_ settings: ClaudePermissionSettings) {
     try? appModel.sessionStore.updatePermissionSettings(
-      terminalId: session.terminalId,
+      tenvySessionId: session.tenvySessionId,
       settings: settings
     )
     if permissionSettingsModified {
@@ -235,9 +235,10 @@ struct InspectorPanelView: View {
 
   private func resetPermissions() {
     permissionsLoaded = false
-    try? appModel.sessionStore.resetPermissionSettings(terminalId: session.terminalId)
+    try? appModel.sessionStore.resetPermissionSettings(tenvySessionId: session.tenvySessionId)
     sessionPermissions = ClaudeSettingsService.mergeForNewSession(projectPath: session.projectPath)
-    launchedPermissionsHash = ""
+    // launchedPermissionsHash is now a computed property from sessionRecord (via @Query) —
+    // resetPermissionSettings clears it in DB, and the @Query observation picks up the change.
     showPermissionRestartWarning = false
     permissionsLoaded = true
   }
@@ -351,7 +352,6 @@ private struct InspectorPathRow: View {
   InspectorPanelView(
     session: session,
     runtimeInfo: info,
-    restartGeneration: 0,
     onAction: { action in print("Inspector action: \(action)") }
   )
   .frame(width: 260, height: 600)

--- a/Tenvy/Features/Permissions/SessionSettingsFileManager.swift
+++ b/Tenvy/Features/Permissions/SessionSettingsFileManager.swift
@@ -25,7 +25,7 @@ import Foundation
 /// Manages per-session settings files written to Application Support.
 ///
 /// Each active Claude session with custom permissions gets a settings file at:
-/// `~/Library/Application Support/Tenvy/session-settings/<terminalId>.json`
+/// `~/Library/Application Support/Tenvy/session-settings/<tenvySessionId>.json`
 ///
 /// The file is passed to Claude CLI via `--settings` at launch and cleaned up
 /// when the session is deactivated.
@@ -40,11 +40,11 @@ struct SessionSettingsFileManager {
 
   /// Write a settings file for a session. Returns the file path string for the `--settings` flag.
   @discardableResult
-  static func writeSettingsFile(terminalId: String, settings: ClaudePermissionSettings) throws -> String {
+  static func writeSettingsFile(tenvySessionId: String, settings: ClaudePermissionSettings) throws -> String {
     let dir = baseDirectory
     try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
-    let fileURL = dir.appendingPathComponent("\(terminalId).json")
+    let fileURL = dir.appendingPathComponent("\(tenvySessionId).json")
 
     // Build the settings JSON that Claude CLI expects
     var settingsDict: [String: Any] = [:]
@@ -64,8 +64,8 @@ struct SessionSettingsFileManager {
   }
 
   /// Remove the settings file for a session.
-  static func removeSettingsFile(terminalId: String) {
-    let fileURL = baseDirectory.appendingPathComponent("\(terminalId).json")
+  static func removeSettingsFile(tenvySessionId: String) {
+    let fileURL = baseDirectory.appendingPathComponent("\(tenvySessionId).json")
     try? FileManager.default.removeItem(at: fileURL)
   }
 

--- a/Tenvy/Features/Session/ClaudeSession.swift
+++ b/Tenvy/Features/Session/ClaudeSession.swift
@@ -40,9 +40,9 @@ struct ClaudeSession: Identifiable, Hashable {
   let filePath: URL?
   var isNewSession: Bool = false
 
-  /// Stable identifier for terminal view identity - persists through session sync
-  /// This prevents SwiftUI from recreating the terminal when session ID changes
-  let terminalId: String
+  /// Stable Tenvy session identifier — persists through session sync.
+  /// Prevents SwiftUI from recreating the terminal when Claude session ID changes.
+  let tenvySessionId: String
 
   init(
     id: String,
@@ -52,7 +52,7 @@ struct ClaudeSession: Identifiable, Hashable {
     lastModified: Date,
     filePath: URL?,
     isNewSession: Bool = false,
-    terminalId: String? = nil
+    tenvySessionId: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -61,7 +61,7 @@ struct ClaudeSession: Identifiable, Hashable {
     self.lastModified = lastModified
     self.filePath = filePath
     self.isNewSession = isNewSession
-    self.terminalId = terminalId ?? id
+    self.tenvySessionId = tenvySessionId ?? id
   }
 
   var displayPath: String {

--- a/Tenvy/Features/Session/SessionListView.swift
+++ b/Tenvy/Features/Session/SessionListView.swift
@@ -45,7 +45,7 @@ struct SessionListView: View {
   var activatedSessions: [String: ClaudeSession]
   /// Session IDs that are part of this window's split tree.
   var splitSessionIds: Set<String> = []
-  /// Runtime titles for plain terminals (keyed by terminalId).
+  /// Runtime titles for plain terminals (keyed by tenvySessionId).
   var plainTerminalTitles: [String: String] = [:]
 
   /// Local selection state for responsive UI - synced with selectedSession
@@ -157,7 +157,7 @@ struct SessionListView: View {
             SessionRowView(
               sessionModel: ClaudeSessionModel(session: session, runtime: runtimeState.info(for: session.id)),
               isActive: true,
-              titleOverride: plainTerminalTitles[session.terminalId]
+              titleOverride: plainTerminalTitles[session.tenvySessionId]
             )
               .tag(session)
               .contextMenu { sessionContextMenu(for: session) }

--- a/Tenvy/Features/Session/SessionManager.swift
+++ b/Tenvy/Features/Session/SessionManager.swift
@@ -253,7 +253,7 @@ class SessionManager {
 
   func deleteSession(_ session: ClaudeSession) throws {
     // Remove from persistent DB
-    try? sessionStore?.deleteSession(terminalId: session.terminalId)
+    try? sessionStore?.deleteSession(tenvySessionId: session.tenvySessionId)
 
     guard let filePath = session.filePath else {
       // New session without a file - just remove from list
@@ -314,7 +314,7 @@ class SessionManager {
     }
 
     // Update in persistent DB
-    try? sessionStore?.updateTitle(terminalId: session.terminalId, title: newTitle)
+    try? sessionStore?.updateTitle(tenvySessionId: session.tenvySessionId, title: newTitle)
   }
 }
 

--- a/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
+++ b/Tenvy/Features/Terminal/ClaudeSessionTerminalView.swift
@@ -65,16 +65,16 @@ struct ClaudeSessionTerminalView: NSViewRepresentable {
       // - Tools removed by the user → pass as --disallowedTools (deny overrides allow)
       // - Tools added by the user → pass as --allowedTools
       // - Explicit deny list → also passed as --disallowedTools
-      if let terminalId = session?.terminalId,
+      if let tenvySessionId = session?.tenvySessionId,
          let record = try? AppDatabase.shared.databaseReader.read({ db in
-           try SessionRecord.fetchOne(db, key: terminalId)
+           try SessionRecord.fetchOne(db, key: tenvySessionId)
          }),
          let permSettings = record.decodedPermissionSettings {
         // Store the hash of what we're launching with so the Inspector can detect changes
         let newHash = permSettings.contentHash
         if record.launchedPermissionsHash != newHash {
           try? AppDatabase.shared.databaseWriter.write { db in
-            if var rec = try SessionRecord.fetchOne(db, key: terminalId) {
+            if var rec = try SessionRecord.fetchOne(db, key: tenvySessionId) {
               rec.launchedPermissionsHash = newHash
               try rec.update(db)
             }
@@ -108,7 +108,7 @@ struct ClaudeSessionTerminalView: NSViewRepresentable {
 
       let launch = TerminalEnvironment.shellArgs(executable: claudePath, args: args, currentDirectory: session?.workingDirectory ?? NSHomeDirectory(), initScript: initScript)
 
-      hostView.setupSurface(launch: launch, workingDirectory: session?.workingDirectory ?? NSHomeDirectory(), terminalId: session?.terminalId, onAction: onAction)
+      hostView.setupSurface(launch: launch, workingDirectory: session?.workingDirectory ?? NSHomeDirectory(), tenvySessionId: session?.tenvySessionId, onAction: onAction)
       hostView.contextMenuProvider = { [weak hostView] in
         guard let hostView else { return NSMenu() }
         let target = SessionMenuTarget(onAction: hostView.onAction)

--- a/Tenvy/Features/Terminal/GhosttyHostView.swift
+++ b/Tenvy/Features/Terminal/GhosttyHostView.swift
@@ -96,12 +96,12 @@ final class GhosttyHostView: NSView {
   // MARK: - Surface Setup
 
   /// Creates the Ghostty terminal surface with the given launch command.
-  /// - Parameter terminalId: Passed to `TerminalEnvironment.build()` to set `TENVY_TERMINAL_ID`.
+  /// - Parameter tenvySessionId: Passed to `TerminalEnvironment.build()` to set `TENVY_SESSION_ID`.
   ///   Pass nil for plain terminals (they don't need hook event mapping).
   func setupSurface(
     launch: (executable: String, args: [String]),
     workingDirectory: String,
-    terminalId: String? = nil,
+    tenvySessionId: String? = nil,
     onAction: @escaping (TerminalAction) -> Void
   ) {
     self.onAction = onAction
@@ -114,7 +114,7 @@ final class GhosttyHostView: NSView {
     launchScriptPath = scriptPath
     let command = "\(launch.executable) -l \(scriptPath)"
 
-    let envVars = TerminalEnvironment.build(terminalId: terminalId).reduce(into: [String: String]()) { dict, pair in
+    let envVars = TerminalEnvironment.build(tenvySessionId: tenvySessionId).reduce(into: [String: String]()) { dict, pair in
       let parts = pair.split(separator: "=", maxSplits: 1)
       if parts.count == 2 { dict[String(parts[0])] = String(parts[1]) }
     }

--- a/Tenvy/Features/Terminal/HookEventService.swift
+++ b/Tenvy/Features/Terminal/HookEventService.swift
@@ -33,15 +33,15 @@ struct HookEvent: Codable {
   let message: String?
   let toolInput: ToolInput?
   let timestamp: String
-  /// Tenvy terminal ID — enables reliable session ID mapping without heuristics.
-  /// Present when Claude was launched from Tenvy with `TENVY_TERMINAL_ID` set.
-  let terminalId: String?
+  /// Tenvy session ID — enables reliable session ID mapping without heuristics.
+  /// Present when Claude was launched from Tenvy with `TENVY_SESSION_ID` set.
+  let tenvySessionId: String?
 
   enum CodingKeys: String, CodingKey {
     case sessionId = "session_id"
     case event, state, cwd, tool, message, timestamp
     case toolInput = "tool_input"
-    case terminalId = "terminal_id"
+    case tenvySessionId = "terminal_id"
   }
 
   /// Parse timestamp to Date
@@ -121,7 +121,7 @@ final class HookEventService {
   /// Latest permission message per session (for permission prompts)
   private(set) var sessionMessages: [String: String] = [:]
 
-  /// Callback when a session state changes (sessionId, state, tool, message, eventTime, terminalId)
+  /// Callback when a session state changes (sessionId, state, tool, message, eventTime, tenvySessionId)
   var onStateChange: ((String, HookState, String?, String?, Date?, String?) -> Void)?
 
   init() {
@@ -285,8 +285,8 @@ final class HookEventService {
       sessionTimestamps[sessionId] = date
     }
 
-    // Notify callback with event timestamp, message, and terminal ID
-    onStateChange?(sessionId, state, event.tool, permissionMessage, eventDate, event.terminalId)
+    // Notify callback with event timestamp, message, and Tenvy session ID
+    onStateChange?(sessionId, state, event.tool, permissionMessage, eventDate, event.tenvySessionId)
   }
 
   /// Get the current hook state for a session

--- a/Tenvy/Features/Terminal/HookInstallationService.swift
+++ b/Tenvy/Features/Terminal/HookInstallationService.swift
@@ -79,7 +79,7 @@ final class HookInstallationService {
   }
 
   /// Ensure hooks are installed and up-to-date.
-  /// Installs if missing, upgrades if the script lacks `TENVY_TERMINAL_ID` support.
+  /// Installs if missing, upgrades if the script lacks `TENVY_SESSION_ID` support.
   func checkInstallationStatus() {
     let scriptExists = FileManager.default.fileExists(atPath: hookScriptPath.path)
     let hooks = loadHooks()
@@ -100,7 +100,7 @@ final class HookInstallationService {
     // Check if installed script has terminal_id support
     var scriptUpToDate = false
     if scriptExists, let content = try? String(contentsOf: hookScriptPath, encoding: .utf8) {
-      scriptUpToDate = content.contains("TENVY_TERMINAL_ID")
+      scriptUpToDate = content.contains("TENVY_SESSION_ID")
     }
 
     let needsInstall = !scriptExists || !settingsConfigured || !scriptUpToDate
@@ -354,7 +354,7 @@ final class HookInstallationService {
     TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
     NOTIFICATION_TYPE=$(echo "$INPUT" | jq -r '.notification_type // empty')
     # Terminal ID from Tenvy — enables reliable session ID mapping
-    TERMINAL_ID="${TENVY_TERMINAL_ID:-}"
+    TERMINAL_ID="${TENVY_SESSION_ID:-}"
 
     # Skip if no session ID
     if [ -z "$SESSION_ID" ]; then

--- a/Tenvy/Features/Terminal/PaneHeader/PaneHeaderDragSource.swift
+++ b/Tenvy/Features/Terminal/PaneHeader/PaneHeaderDragSource.swift
@@ -18,20 +18,20 @@ extension NSPasteboard.PasteboardType {
 
 /// SwiftUI wrapper for the AppKit drag source that covers the entire header.
 struct PaneHeaderDragSourceView: NSViewRepresentable {
-  let terminalId: String
+  let tenvySessionId: String
   let snapshotProvider: () -> NSImage?
   var hasIDEButton: Bool = false
 
   func makeNSView(context: Context) -> PaneHeaderDragSourceNSView {
     let view = PaneHeaderDragSourceNSView()
-    view.terminalId = terminalId
+    view.tenvySessionId = tenvySessionId
     view.snapshotProvider = snapshotProvider
     view.hasIDEButton = hasIDEButton
     return view
   }
 
   func updateNSView(_ nsView: PaneHeaderDragSourceNSView, context: Context) {
-    nsView.terminalId = terminalId
+    nsView.tenvySessionId = tenvySessionId
     nsView.snapshotProvider = snapshotProvider
     let changed = nsView.hasIDEButton != hasIDEButton
     nsView.hasIDEButton = hasIDEButton
@@ -52,7 +52,7 @@ struct PaneHeaderDragSourceView: NSViewRepresentable {
 final class PaneHeaderDragSourceNSView: NSView, NSDraggingSource {
   private static let previewScale: CGFloat = 0.2
 
-  var terminalId: String = ""
+  var tenvySessionId: String = ""
   var snapshotProvider: (() -> NSImage?)?
   var hasIDEButton: Bool = false
 
@@ -114,9 +114,9 @@ final class PaneHeaderDragSourceNSView: NSView, NSDraggingSource {
   override func mouseDragged(with event: NSEvent) {
     guard !isTracking else { return }
 
-    // Write terminalId to pasteboard
+    // Write tenvySessionId to pasteboard
     let pasteboardItem = NSPasteboardItem()
-    pasteboardItem.setString(terminalId, forType: .tenvyPaneId)
+    pasteboardItem.setString(tenvySessionId, forType: .tenvyPaneId)
 
     let item = NSDraggingItem(pasteboardWriter: pasteboardItem)
 
@@ -200,7 +200,7 @@ final class PaneHeaderDragSourceNSView: NSView, NSDraggingSource {
           name: .paneDragEndedNoTarget,
           object: nil,
           userInfo: [
-            Notification.paneDragTerminalIdKey: terminalId,
+            Notification.paneDragTenvySessionIdKey: tenvySessionId,
             Notification.paneDragEndedPointKey: screenPoint,
           ]
         )
@@ -219,6 +219,6 @@ extension Notification.Name {
 }
 
 extension Notification {
-  static let paneDragTerminalIdKey = "terminalId"
+  static let paneDragTenvySessionIdKey = "tenvySessionId"
   static let paneDragEndedPointKey = "endedAtPoint"
 }

--- a/Tenvy/Features/Terminal/PaneHeader/PaneHeaderView.swift
+++ b/Tenvy/Features/Terminal/PaneHeader/PaneHeaderView.swift
@@ -13,10 +13,10 @@ enum PaneHeaderAction {
 ///
 /// Displays the session/terminal title on the left and a close button on the right.
 /// The entire header is draggable — initiating an AppKit drag session with the
-/// pane's `terminalId` on the pasteboard for drop-to-split rearrangement.
+/// pane's `tenvySessionId` on the pasteboard for drop-to-split rearrangement.
 struct PaneHeaderView: View {
   let title: String
-  let terminalId: String
+  let tenvySessionId: String
   var isSelected: Bool = false
   var isFileDropTarget: Bool = false
   var runtimeInfo: SessionRuntimeInfo?
@@ -78,7 +78,7 @@ struct PaneHeaderView: View {
     ZStack {
       // Drag source covers the full header
       PaneHeaderDragSourceView(
-        terminalId: terminalId,
+        tenvySessionId: tenvySessionId,
         snapshotProvider: snapshotProvider,
         hasIDEButton: ideResult?.primary != nil
       )
@@ -144,7 +144,7 @@ struct PaneHeaderView: View {
   VStack(spacing: 0) {
     PaneHeaderView(
       title: "claude --resume abc123",
-      terminalId: "test",
+      tenvySessionId: "test",
       snapshotProvider: { nil },
       onAction: { _ in }
     )

--- a/Tenvy/Features/Terminal/SessionRuntimeState.swift
+++ b/Tenvy/Features/Terminal/SessionRuntimeState.swift
@@ -34,6 +34,11 @@ final class SessionRuntimeInfo {
   var pid: pid_t = 0      // Claude process PID (for display)
   var shellPid: pid_t = 0 // Shell process PID (parent, for termination)
 
+  /// Ephemeral Ghostty terminal instance ID. Changes every time the terminal surface is
+  /// (re)created — used as SwiftUI view identity (`.id(ghosttyInstanceId)`) so that
+  /// permission restarts force a new `makeNSView` call without generation counters.
+  var ghosttyInstanceId: String = UUID().uuidString
+
   // Hook-based state tracking
   var hookState: HookState?       // Current state from hooks (more accurate than CPU)
   var currentTool: String?        // Currently executing tool (if any)
@@ -106,6 +111,7 @@ final class SessionRuntimeInfo {
     activatedAt = nil
     hasUserInteracted = false
     gitBranch = nil
+    ghosttyInstanceId = UUID().uuidString
   }
 }
 

--- a/Tenvy/Features/Terminal/TerminalEnvironment.swift
+++ b/Tenvy/Features/Terminal/TerminalEnvironment.swift
@@ -26,9 +26,9 @@ import Foundation
 struct TerminalEnvironment {
   /// Build the initial environment to pass to the shell process.
   /// The shell itself will source ~/.zprofile and ~/.zshrc and augment this further.
-  /// - Parameter terminalId: If non-nil, sets `TENVY_TERMINAL_ID` so the hook script
+  /// - Parameter tenvySessionId: If non-nil, sets `TENVY_SESSION_ID` so the hook script
   ///   can include it in events for reliable session ID mapping. Pass nil for plain terminals.
-  static func build(terminalId: String? = nil) -> [String] {
+  static func build(tenvySessionId: String? = nil) -> [String] {
     var env: [String] = ProcessInfo.processInfo.environment.map { "\($0.key)=\($0.value)" }
     env.setVariable("TERM", value: "xterm-256color")
     env.setVariable("COLORTERM", value: "truecolor")
@@ -43,9 +43,9 @@ struct TerminalEnvironment {
     for (key, value) in AppSettings.shared.customEnvironmentVariables {
       env.setVariable(key, value: value)
     }
-    // Set terminal ID for hook event mapping (Claude sessions only, not plain terminals)
-    if let terminalId {
-      env.setVariable("TENVY_TERMINAL_ID", value: terminalId)
+    // Set session ID for hook event mapping (Claude sessions only, not plain terminals)
+    if let tenvySessionId {
+      env.setVariable("TENVY_SESSION_ID", value: tenvySessionId)
     }
     return env
   }


### PR DESCRIPTION
## Summary

- **Rename `terminalId` → `tenvySessionId`** across ~100 call sites (32 files) — clarifies that this is Tenvy's stable session identifier, not a terminal ID
- **Rename `TENVY_TERMINAL_ID` → `TENVY_SESSION_ID`** env var (hook script + installation service)
- **Replace `terminalViewGenerations` counter** with explicit `ghosttyInstanceId` on `SessionRuntimeInfo` — eliminates the generation counter workaround for permission restarts
- **Rework `InspectorPanelView`** to use `@Query<SessionByTenvyIdRequest>` for reactive DB observation instead of `restartGeneration` prop passed from parent
- **GRDB migration** `v3_renameTerminalIdToTenvySessionId` renames the DB column

The JSON wire format key `"terminal_id"` in hook events is unchanged (external protocol).

## Test plan

- [ ] Launch app — verify existing sessions survive DB migration (column renamed, data preserved)
- [ ] Create new session — verify `TENVY_SESSION_ID` env var is set and hook events still map correctly
- [ ] Edit permissions in Inspector → click Restart → verify terminal recreates and restart button disappears
- [ ] Split a session → verify both panes work, drag-rearrange works, close pane works
- [ ] Drag pane outside window → verify new window created with working terminal
- [ ] Verify hook installation auto-upgrades the script (detects `TENVY_SESSION_ID` in version check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)