### PR TITLE
fix: prevent migration crash when terminalId column already renamed

### DIFF
--- a/Tenvy/Core/AppDatabase.swift
+++ b/Tenvy/Core/AppDatabase.swift
@@ -107,7 +107,13 @@ struct AppDatabase {
     }
 
     migrator.registerMigration("v3_renameTerminalIdToTenvySessionId") { db in
-      try db.execute(sql: "ALTER TABLE sessionRecord RENAME COLUMN terminalId TO tenvySessionId")
+      // v1 was updated in-place to use tenvySessionId directly.
+      // Only rename if the old column still exists (pre-v3 databases).
+      let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(sessionRecord)")
+      let hasTerminalId = columns.contains { $0["name"] as String == "terminalId" }
+      if hasTerminalId {
+        try db.execute(sql: "ALTER TABLE sessionRecord RENAME COLUMN terminalId TO tenvySessionId")
+      }
     }
 
     return migrator


### PR DESCRIPTION
## Summary
- App crashes on update with `SQLite error 1: no such column: "terminalId"` because v1 migration was retroactively edited to use `tenvySessionId` directly, but v3 still unconditionally tries to rename the old column
- Fix: check `PRAGMA table_info` before attempting the rename — handles both old DBs (need rename) and new DBs (column already correct)

## Test plan
- [ ] Fresh install: app launches without crash
- [ ] Update from pre-v3 database: migration renames column successfully
- [ ] Update from post-v3 database: migration is a no-op, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)