### PR TITLE
feat: make scheduled-task worktree optional (default off); fix detail sub-list

### DIFF
--- a/.claude/memory/project_scheduled_tasks.md
+++ b/.claude/memory/project_scheduled_tasks.md
@@ -6,14 +6,18 @@
 ## What it is
 
 Recurring Claude Code "tasks" the user defines once. Each firing opens a fresh background
-window with a Claude session pre-seeded with a user-provided prompt, running in its own
-git worktree.
+window with a Claude session pre-seeded with a user-provided prompt. By default the run
+executes directly in the chosen folder (no git involvement); when the task opts in to
+`useWorktree`, each firing creates a fresh git worktree off the folder's current branch
+instead.
 
 ## Surface area
 
-- New tables (GRDB migrations v4 + v5):
+- New tables (GRDB migrations v4 + v5 + v6):
   - `scheduledTask` — task definitions.
   - `sessionRecord.scheduledTaskId` — optional FK from sessions to their parent task.
+  - `scheduledTask.useWorktree` — per-task flag (migration v6). The same migration
+    wipes pre-v6 rows because they were created under the worktree-always assumption.
 - New files under `Tenvy/Features/Scheduled/`:
   - `ScheduledTask.swift` — value types (`Frequency`, `Weekday`, `PromptKind`, `RunStatus`),
     `nextRunAt` algorithm, branch/slug naming helpers.
@@ -104,14 +108,25 @@ for symmetry). This binds the value to the flag and leaves the trailing prompt
 arg untouched. If a future change reverts these to separate `--flag` / `value`
 args, scheduled tasks will silently lose their prompts again.
 
-## Worktree naming
+## Worktree mode (per task, default OFF)
 
-- Branch: `tenvy/scheduled/<slug>/<YYYYMMDD-HHMMSS>` (UTC timestamp).
-- Worktree dir name: `<slug>-<YYYYMMDD-HHMMSS>` (flat, no slashes).
-- On branch collision: append `-1`…`-9`. Beyond that → fail the run.
-- `customWorktreeBase` overrides the default `<repo>/.claude/worktrees` parent.
-- **Worktrees are retained until the task itself is deleted** (per design decision).
-  Disk-growth implications were explicitly accepted in §13 risks.
+Each task carries a `useWorktree: Bool` flag. The create form's "Create a fresh git
+worktree for every run" checkbox writes this flag; the default is **OFF**.
+
+- **OFF (in-place)**: `ScheduledTaskExecutor.prepareWorkspace` skips git entirely and
+  returns `Prepared(repoRoot: task.workingDirectory, branchName: nil, worktreePath: nil)`.
+  The session record's `branchName` and `worktreePath` are nil, so the delete dialog's
+  worktree-cleanup step naturally skips them. The folder is **not required** to be a git
+  repository in this mode — no `git init` prompt is offered.
+- **ON (worktree-per-run)**:
+  - Branch: `tenvy/scheduled/<slug>/<YYYYMMDD-HHMMSS>` (UTC timestamp).
+  - Worktree dir name: `<slug>-<YYYYMMDD-HHMMSS>` (flat, no slashes).
+  - On branch collision: append `-1`…`-9`. Beyond that → fail the run.
+  - `customWorktreeBase` overrides the default `<repo>/.claude/worktrees` parent.
+  - Non-git folders require the "Initialize git on first run" opt-in (gated by
+    `pendingGitInit` on the record).
+  - **Worktrees are retained until the task itself is deleted** (per design decision).
+    Disk-growth implications were explicitly accepted in §13 risks.
 
 ## Sidebar surface
 
@@ -126,6 +141,23 @@ returns to the flat list).
 Status icon + relative countdown only. Format: `"in 12s"`, `"in 3m 45s"`, `"in 3 days"`,
 `"due now"`. `TimelineView(.periodic(...))` re-renders at an interval scaled to the
 remaining time (1s → 15s → 60s → 600s).
+
+### Detail-view sub-list — resolving runtime state
+
+The sessions sub-list inside `ScheduledTaskDetailView` must show the same live PID/CPU/
+hook state as the main list. Two gotchas to preserve:
+
+1. **Tap action goes through `onSessionSelect` → `onAction(.select(...))`** on the parent
+   `SessionListView`, *not* by setting the `selectedSession` binding directly. Setting
+   the binding bypasses `ContentViewModel.selectSession` (window registry, activation,
+   runtime wiring), so the click would appear to do nothing.
+2. **Row data must come from the live activated session, not the DB record.** The DB
+   record's `isActive` flag is a snapshot that lags hook events, and its `claudeSessionId`
+   may not yet match the runtime registry key (the registry is keyed by the *current*
+   `session.id` — temp UUID before hook sync, Claude id after). The detail view looks up
+   the live session by stable `tenvySessionId` in `appModel.activatedSessions`; when
+   found, it passes that session's `id` to the runtime registry and `isActive: true` to
+   `SessionRowView`. Falls back to the DB record only for history rows.
 
 ## Decisions explicitly out of scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ macOS app for managing and resuming Claude Code CLI sessions with a native trans
 ## Quick Overview
 
 - **Session Management**: Browse, resume, rename, and delete Claude Code sessions
-- **Scheduled Tasks**: Recurring sessions with a user-provided prompt that run on a fixed schedule (minutes/hours/days/weeks) inside fresh worktrees, supervised by Tenvy
+- **Scheduled Tasks**: Recurring sessions with a user-provided prompt that run on a fixed schedule (minutes/hours/days/weeks). Each task optionally creates a fresh git worktree per run (off by default); when worktree is off, the run executes directly in the working folder with no git involvement
 - **Embedded Terminal**: Ghostty terminal with CPU-based state monitoring
 - **Split Panes**: Tree-based split layout (Ghostty-style) — splitting only divides the focused pane, not all panes. Both splits and new session creation intercept to offer git worktree creation for parallel branch work
 - **Multi-Window Support**: Each session runs in isolated window/tab with single process
@@ -395,7 +395,8 @@ Two-level permission management: global (App Settings) and per-session (Inspecto
 
 Full design and decision log lives at [scheduled-tasks.md](./scheduled-tasks.md). Quick reference for implementation invariants:
 
-- **DB**: `scheduledTask` table (migration v4) + `sessionRecord.scheduledTaskId` foreign-key column (migration v5). Spawned sessions look identical to normal sessions plus the `scheduledTaskId` link.
+- **DB**: `scheduledTask` table (migration v4) + `sessionRecord.scheduledTaskId` foreign-key column (migration v5) + `scheduledTask.useWorktree` column (migration v6, which also wipes pre-v6 rows because the worktree-always assumption was baked into the prior schema). Spawned sessions look identical to normal sessions plus the `scheduledTaskId` link.
+- **Worktree per run**: per-task `useWorktree` flag, default OFF. When ON, `ScheduledTaskExecutor.prepareWorkspace` builds a fresh `tenvy/scheduled/<slug>/<ts>` worktree exactly as before (git-init prompt for non-git folders applies). When OFF, the executor short-circuits past all git logic and runs claude in `task.workingDirectory` directly — the folder doesn't need to be a git repo. The session record's `branchName` and `worktreePath` are nil in the in-place case, so the delete dialog's worktree-cleanup step naturally skips them.
 - **Scheduler**: `ScheduledTaskScheduler` runs a single `Timer` every **5 seconds**. On launch it rolls `nextRunAt` forward for any task whose due time was missed while the app was closed — missed runs are **never** fired (decision: skip-missed).
 - **One window per task** is enforced by the **overlap rule** in `ScheduledTaskExecutor.decideOverlap`, not by any registry: previous session in `waiting` → auto-close and proceed; previous in any other non-ended state → skip; previous gone / ended → proceed. The `started` / nil hook states count as still-running for safety.
 - **Window opening**: each firing creates a fresh `NSWindow` via `NSHostingController<ContentView>` (same pattern as `handleDragToNewWindow`), then calls `orderFront(nil)` — **not** `makeKeyAndOrderFront` — so the window appears without stealing focus from the user's foreground app. Dock icon may still bounce; that's accepted.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -105,8 +105,9 @@ Recurring Claude Code "tasks" that run on a fixed schedule (minutes / hours / da
 The sidebar toolbar's existing **+** button is a split menu: clicking it directly opens the regular New Session flow, and its dropdown adds a **New Scheduled Task** item that opens `CreateScheduledTaskView`. The form collects:
 
 - **Name** — used for session titles, branch slugs, and sidebar rows.
-- **Working folder** — required. If it isn't a git repo, the user must opt in to a "git init on first run" checkbox.
-- **Worktree base** (optional) — defaults to `<repo>/.claude/worktrees`.
+- **Working folder** — required. The folder does not have to be a git repository unless the task uses worktrees (see next field).
+- **Create a fresh git worktree for every run** — a checkbox, **default OFF**. When OFF, each firing runs claude directly in the working folder (no branch isolation, no git involvement). When ON, each firing creates a fresh `tenvy/scheduled/<slug>/<ts>` worktree off the folder's current branch; if the folder isn't yet a git repo, the user must additionally opt in to the "git init on first run" checkbox that appears below.
+- **Worktree base** (optional, only shown when worktree mode is ON) — defaults to `<repo>/.claude/worktrees`.
 - **Frequency** — unit (Minutes/Hours/Days/Weeks) + value (1–999). Days and weeks additionally take a time-of-day; weeks add a multi-select weekday picker.
 - **Prompt** — segmented Text / File. Text is stored inline; file paths are re-read on every execution.
 - **Permissions** — embedded `PermissionEditorView`, pre-filled from `ClaudeSettingsService.mergeForNewSession(...)`.
@@ -133,7 +134,7 @@ When the in-app scheduler decides a task is due, the executor:
 
 1. Runs the **overlap rule** — see below.
 2. Resolves the prompt up front (text is used as-is; file prompts are re-read each firing, 1 MB cap).
-3. Detects or initializes the git repo, creates a fresh worktree under `tenvy/scheduled/<slug>/<YYYYMMDD-HHMMSS>` (worktree dir name uses the same slug+timestamp).
+3. If the task has `useWorktree` enabled: detects or initializes the git repo and creates a fresh worktree under `tenvy/scheduled/<slug>/<YYYYMMDD-HHMMSS>`. Otherwise: skips all git work and uses `task.workingDirectory` directly.
 4. Inserts a new `SessionRecord` linked to the scheduled task, with a title of the form `"<Task name> — yyyy-MM-dd HH:mm"` and the task's snapshotted permission settings.
 5. Registers a power assertion (`ScheduledTaskPowerGuard`) so macOS won't idle-sleep or start the screen saver while the session is alive. Released (1-second debounce) when the session is deactivated.
 6. Opens a new `NSWindow` via `NSHostingController<ContentView>` and calls `orderFront(nil)` — **without** `makeKeyAndOrderFront`. The window appears but doesn't steal focus from the user's foreground app.
@@ -168,7 +169,7 @@ Skipped runs do not appear in the sub-list (they didn't create a session), but t
 
 ### Worktree retention
 
-Spawned worktrees are **kept forever until the task itself is deleted** (decided trade-off — disk usage grows linearly with runs). The delete dialog is the canonical bulk-cleanup mechanism.
+When a task has `useWorktree` enabled, spawned worktrees are **kept forever until the task itself is deleted** (decided trade-off — disk usage grows linearly with runs). The delete dialog is the canonical bulk-cleanup mechanism. In-place tasks (worktree off) leave nothing on disk between runs.
 
 ### Notifications
 

--- a/Tenvy/Core/AppDatabase.swift
+++ b/Tenvy/Core/AppDatabase.swift
@@ -164,6 +164,23 @@ struct AppDatabase {
       )
     }
 
+    migrator.registerMigration("v6_addUseWorktreeAndWipeScheduledTasks") { db in
+      // Scheduled tasks created before this migration assumed worktree-always; the new
+      // model has a per-task `useWorktree` flag with default OFF, so old rows would be
+      // semantically reinterpreted. Wipe them rather than try to migrate behavior.
+      try db.execute(sql: "DELETE FROM scheduledTask")
+      try db.execute(
+        sql: "UPDATE sessionRecord SET scheduledTaskId = NULL WHERE scheduledTaskId IS NOT NULL"
+      )
+      let columns = try Row.fetchAll(db, sql: "PRAGMA table_info(scheduledTask)")
+      let hasColumn = columns.contains { $0["name"] as String == "useWorktree" }
+      if !hasColumn {
+        try db.alter(table: "scheduledTask") { t in
+          t.add(column: "useWorktree", .boolean).notNull().defaults(to: false)
+        }
+      }
+    }
+
     return migrator
   }
 

--- a/Tenvy/Core/ScheduledTaskRecord.swift
+++ b/Tenvy/Core/ScheduledTaskRecord.swift
@@ -37,11 +37,18 @@ struct ScheduledTaskRecord: Codable, FetchableRecord, PersistableRecord, Identif
   var workingDirectory: String
 
   /// Optional override of the worktree base directory. nil → `WorktreeService.defaultWorktreePath`.
+  /// Only consulted when `useWorktree == true`.
   var customWorktreeBase: String?
 
   /// True when the folder was not yet a git repo at creation time; the first execution
-  /// will `git init` the folder before creating the worktree.
+  /// will `git init` the folder before creating the worktree. Only meaningful when
+  /// `useWorktree == true`.
   var pendingGitInit: Bool
+
+  /// When true, every execution creates a fresh git worktree off the folder's current
+  /// branch. When false, executions run directly in `workingDirectory` with no git
+  /// involvement — the folder doesn't even need to be a git repository.
+  var useWorktree: Bool
 
   /// Frequency unit raw value: "minute"|"hour"|"day"|"week".
   var frequencyUnit: String

--- a/Tenvy/Features/Scheduled/CreateScheduledTaskView.swift
+++ b/Tenvy/Features/Scheduled/CreateScheduledTaskView.swift
@@ -113,11 +113,15 @@ struct CreateScheduledTaskView: View {
         Button("Choose…") { pickFolder() }
       }
 
+      Toggle("Create a fresh git worktree for every run", isOn: $model.useWorktree)
+        .toggleStyle(.checkbox)
+        .font(.caption)
+
       Text(model.gitStrategyDescription)
         .font(.caption2)
         .foregroundColor(.secondary)
 
-      if model.shouldOfferGitInit {
+      if model.useWorktree && model.shouldOfferGitInit {
         Toggle(
           "Initialize git in this folder on first run",
           isOn: $model.acknowledgeGitInit
@@ -126,14 +130,16 @@ struct CreateScheduledTaskView: View {
         .font(.caption)
       }
 
-      DisclosureGroup("Worktree location (optional)") {
-        HStack {
-          TextField("Default: <repo>/.claude/worktrees", text: $model.customWorktreeBase)
-            .textFieldStyle(.roundedBorder)
-          Button("Browse…") { pickWorktreeBase() }
+      if model.useWorktree {
+        DisclosureGroup("Worktree location (optional)") {
+          HStack {
+            TextField("Default: <repo>/.claude/worktrees", text: $model.customWorktreeBase)
+              .textFieldStyle(.roundedBorder)
+            Button("Browse…") { pickWorktreeBase() }
+          }
         }
+        .font(.caption)
       }
-      .font(.caption)
     }
   }
 
@@ -301,9 +307,13 @@ final class ScheduledTaskFormModel {
   var workingDirectory: String = ""
   var customWorktreeBase: String = ""
 
+  /// Default OFF: most tasks run in-place. Users opt in to per-run worktrees when
+  /// they want branch isolation.
+  var useWorktree: Bool = false
+
   /// Set by `refreshGitStatus` after the user picks a folder.
   private(set) var folderIsGitRepo: Bool = false
-  /// User must explicitly opt in to git init for non-git folders.
+  /// User must explicitly opt in to git init for non-git folders (only when useWorktree).
   var acknowledgeGitInit: Bool = false
 
   var frequencyUnit: ScheduledTaskFrequencyUnit = .hour
@@ -346,8 +356,11 @@ final class ScheduledTaskFormModel {
 
   var gitStrategyDescription: String {
     if workingDirectory.isEmpty { return "" }
+    if !useWorktree {
+      return "Runs directly in the folder. No git required."
+    }
     if folderIsGitRepo {
-      return "Git strategy: worktree (required)"
+      return "Each run creates a fresh worktree off the current branch."
     }
     return "Folder is not a git repository. Tenvy will run `git init` on first execution."
   }
@@ -371,7 +384,7 @@ final class ScheduledTaskFormModel {
     let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return .missingName }
     guard !workingDirectory.isEmpty else { return .missingFolder }
-    if !folderIsGitRepo && !acknowledgeGitInit { return .folderUnsupported }
+    if useWorktree && !folderIsGitRepo && !acknowledgeGitInit { return .folderUnsupported }
 
     switch promptKind {
     case .text:
@@ -401,8 +414,9 @@ final class ScheduledTaskFormModel {
       id: UUID().uuidString,
       name: trimmed,
       workingDirectory: workingDirectory,
-      customWorktreeBase: customWorktreeBase.isEmpty ? nil : customWorktreeBase,
-      pendingGitInit: !folderIsGitRepo,
+      customWorktreeBase: useWorktree && !customWorktreeBase.isEmpty ? customWorktreeBase : nil,
+      pendingGitInit: useWorktree && !folderIsGitRepo,
+      useWorktree: useWorktree,
       frequencyUnit: frequencyUnit.rawValue,
       frequencyValue: frequencyValue,
       timeOfDayHour: frequencyUnit.requiresTimeOfDay ? hourOfTimeOfDay : nil,

--- a/Tenvy/Features/Scheduled/ScheduledTaskDetailView.swift
+++ b/Tenvy/Features/Scheduled/ScheduledTaskDetailView.swift
@@ -33,6 +33,10 @@ struct ScheduledTaskDetailView: View {
   let taskId: String
   var onBack: () -> Void
   var onMissing: () -> Void
+  /// Fires when the user taps a session row. Wired to the sidebar's `onAction(.select(...))`
+  /// so the session goes through `ContentViewModel.selectSession` (window registry, runtime,
+  /// activation) — setting the `selectedSession` binding alone does not open the session.
+  var onSessionSelect: (ClaudeSession) -> Void
 
   @Environment(AppModel.self) private var appModel
   @Query<ScheduledTaskByIdRequest> private var task: ScheduledTaskRecord?
@@ -49,11 +53,13 @@ struct ScheduledTaskDetailView: View {
     taskId: String,
     selectedSession: Binding<ClaudeSession?>,
     onBack: @escaping () -> Void,
-    onMissing: @escaping () -> Void = {}
+    onMissing: @escaping () -> Void = {},
+    onSessionSelect: @escaping (ClaudeSession) -> Void = { _ in }
   ) {
     self.taskId = taskId
     self.onBack = onBack
     self.onMissing = onMissing
+    self.onSessionSelect = onSessionSelect
     self._selectedSession = selectedSession
     self._task = Query(constant: ScheduledTaskByIdRequest(id: taskId))
     self._sessions = Query(constant: SessionsByScheduledTaskRequest(scheduledTaskId: taskId))
@@ -150,8 +156,14 @@ struct ScheduledTaskDetailView: View {
       VStack(alignment: .leading, spacing: 6) {
         if let task {
           detailRow("Folder", value: task.workingDirectory)
-          if let worktreeBase = task.customWorktreeBase, !worktreeBase.isEmpty {
-            detailRow("Worktree base", value: worktreeBase)
+          if task.useWorktree {
+            if let worktreeBase = task.customWorktreeBase, !worktreeBase.isEmpty {
+              detailRow("Worktree base", value: worktreeBase)
+            } else {
+              detailRow("Worktree", value: "Fresh worktree per run")
+            }
+          } else {
+            detailRow("Worktree", value: "Off — runs in folder")
           }
           detailRow("Permissions", value: permissionsSummary(task.decodedPermissionSettings))
           detailRow("Prompt", value: promptPreview(task: task))
@@ -208,16 +220,21 @@ struct ScheduledTaskDetailView: View {
       List {
         Section {
           ForEach(sessions) { record in
-            let session = buildSession(from: record)
+            // Prefer the live activated session — its `id` matches the runtime registry
+            // key (temp UUID before hook sync, Claude session id after), so the row sees
+            // PID/CPU/MEM/hookState. Fall back to the DB record for inactive history rows.
+            let active = activatedSession(for: record)
+            let session = active ?? buildSession(from: record)
+            let isActive = active != nil
             SessionRowView(
               sessionModel: ClaudeSessionModel(
                 session: session,
                 runtime: appModel.runtimeRegistry.info(for: session.id)
               ),
-              isActive: record.isActive
+              isActive: isActive
             )
             .contentShape(Rectangle())
-            .onTapGesture { selectedSession = session }
+            .onTapGesture { onSessionSelect(session) }
           }
         } header: {
           Text("Sessions (\(sessions.count))")
@@ -227,6 +244,14 @@ struct ScheduledTaskDetailView: View {
       }
       .listStyle(.sidebar)
       .scrollContentBackground(.hidden)
+    }
+  }
+
+  /// Look up the currently-activated session for a record by stable `tenvySessionId`.
+  /// Returns nil if the session isn't activated (either never opened or already closed).
+  private func activatedSession(for record: SessionRecord) -> ClaudeSession? {
+    appModel.activatedSessions.values.first {
+      $0.tenvySessionId == record.tenvySessionId
     }
   }
 

--- a/Tenvy/Features/Scheduled/ScheduledTaskExecutor.swift
+++ b/Tenvy/Features/Scheduled/ScheduledTaskExecutor.swift
@@ -93,7 +93,7 @@ final class ScheduledTaskExecutor {
       // unreadable, before we touch git or open a window.
       let promptText = try resolvePromptText(task: task)
 
-      let prepared = try prepareWorktree(task: task, firedAt: firedAt)
+      let prepared = try prepareWorkspace(task: task, firedAt: firedAt)
       let session = makeSession(task: task, prepared: prepared, firedAt: firedAt)
       try insertSessionRecord(task: task, session: session, prepared: prepared, firedAt: firedAt)
 
@@ -118,10 +118,15 @@ final class ScheduledTaskExecutor {
 
   // MARK: - Steps
 
-  private func prepareWorktree(task: ScheduledTaskRecord, firedAt: Date) throws -> Prepared {
+  private func prepareWorkspace(task: ScheduledTaskRecord, firedAt: Date) throws -> Prepared {
     let fm = FileManager.default
     guard fm.fileExists(atPath: task.workingDirectory) else {
       throw ScheduledTaskExecutorError.folderMissing(path: task.workingDirectory)
+    }
+
+    // In-place execution: skip git entirely and run claude in the working folder.
+    if !task.useWorktree {
+      return Prepared(repoRoot: task.workingDirectory, branchName: nil, worktreePath: nil)
     }
 
     let git = appModel.gitService
@@ -183,11 +188,12 @@ final class ScheduledTaskExecutor {
 
   private func makeSession(task: ScheduledTaskRecord, prepared: Prepared, firedAt: Date) -> ClaudeSession {
     let title = "\(task.name) — \(ScheduledTaskNaming.titleTimestamp(firedAt))"
+    let path = prepared.sessionPath
     return ClaudeSession(
       id: UUID().uuidString,
       title: title,
-      projectPath: prepared.worktreePath,
-      workingDirectory: prepared.worktreePath,
+      projectPath: path,
+      workingDirectory: path,
       lastModified: firedAt,
       filePath: nil,
       isNewSession: true,
@@ -202,10 +208,11 @@ final class ScheduledTaskExecutor {
     firedAt: Date
   ) throws {
     let permissionJSON = SessionRecord.encode(task.decodedPermissionSettings)
+    let path = prepared.sessionPath
     let record = SessionRecord(
       tenvySessionId: session.tenvySessionId,
-      workingDirectory: prepared.worktreePath,
-      projectPath: prepared.worktreePath,
+      workingDirectory: path,
+      projectPath: path,
       title: session.title,
       branchName: prepared.branchName,
       worktreePath: prepared.worktreePath,
@@ -431,8 +438,14 @@ final class ScheduledTaskExecutor {
 extension ScheduledTaskExecutor {
   fileprivate struct Prepared {
     let repoRoot: String
-    let branchName: String
-    let worktreePath: String
+    /// Nil when the task runs in-place (no worktree created).
+    let branchName: String?
+    /// Nil when the task runs in-place. When set, equals the worktree directory.
+    let worktreePath: String?
+
+    /// Working directory for the spawned session. Worktree path when one exists,
+    /// the chosen folder otherwise.
+    var sessionPath: String { worktreePath ?? repoRoot }
   }
 }
 

--- a/Tenvy/Features/Scheduled/ScheduledTaskRowView.swift
+++ b/Tenvy/Features/Scheduled/ScheduledTaskRowView.swift
@@ -133,7 +133,7 @@ struct ScheduledTaskRowView: View {
   ScheduledTaskRowView(
     task: ScheduledTaskRecord(
       id: "1", name: "Refresh PRs", workingDirectory: "/tmp",
-      pendingGitInit: false, frequencyUnit: "hour", frequencyValue: 1,
+      pendingGitInit: false, useWorktree: false, frequencyUnit: "hour", frequencyValue: 1,
       timeOfDayHour: nil, timeOfDayMinute: nil, weekdays: nil,
       promptKind: "text", promptText: nil, promptFilePath: nil,
       permissionSettings: "{}", enabled: true,
@@ -148,7 +148,7 @@ struct ScheduledTaskRowView: View {
   ScheduledTaskRowView(
     task: ScheduledTaskRecord(
       id: "1", name: "Refresh PRs", workingDirectory: "/tmp",
-      pendingGitInit: false, frequencyUnit: "hour", frequencyValue: 1,
+      pendingGitInit: false, useWorktree: false, frequencyUnit: "hour", frequencyValue: 1,
       timeOfDayHour: nil, timeOfDayMinute: nil, weekdays: nil,
       promptKind: "text", promptText: nil, promptFilePath: nil,
       permissionSettings: "{}", enabled: true,
@@ -163,7 +163,7 @@ struct ScheduledTaskRowView: View {
   ScheduledTaskRowView(
     task: ScheduledTaskRecord(
       id: "1", name: "Daily summary", workingDirectory: "/tmp",
-      pendingGitInit: false, frequencyUnit: "day", frequencyValue: 1,
+      pendingGitInit: false, useWorktree: false, frequencyUnit: "day", frequencyValue: 1,
       timeOfDayHour: 9, timeOfDayMinute: 0, weekdays: nil,
       promptKind: "text", promptText: nil, promptFilePath: nil,
       permissionSettings: "{}", enabled: true,

--- a/Tenvy/Features/Session/SessionListView.swift
+++ b/Tenvy/Features/Session/SessionListView.swift
@@ -267,7 +267,8 @@ struct SessionListView: View {
         taskId: id,
         selectedSession: $selectedSession,
         onBack: { navigatedScheduledTaskId = nil },
-        onMissing: { navigatedScheduledTaskId = nil }
+        onMissing: { navigatedScheduledTaskId = nil },
+        onSessionSelect: { session in onAction(.select(session)) }
       )
     } else {
       sessionList

--- a/scheduled-tasks.md
+++ b/scheduled-tasks.md
@@ -2,7 +2,9 @@
 
 > Status: **Approved design, ready for implementation.**
 > Owner: Rostyslav.
-> Last updated: 2026-05-15.
+> Last updated: 2026-05-18.
+>
+> **Amendment 2026-05-18 (worktree-optional)**: Decision #5 ("Worktree only") was revised. Tasks now carry a `useWorktree` flag (default OFF). When OFF, the run executes directly in the chosen folder with no git involvement; `customWorktreeBase`, `pendingGitInit`, and the branch/worktree pipeline are skipped. The git-init checkbox in the create form is only shown when worktree is enabled. Migration v6 adds the column and wipes pre-existing scheduled tasks (their worktree-always semantics don't carry over cleanly).
 
 This document is the single source of truth for the Scheduled Tasks feature. It captures every product decision agreed during planning, the resulting data model, the runtime semantics, the UI surface, the edge cases, and the implementation order. Open it before writing any code in this feature; if you change a decision, change this file first.
 


### PR DESCRIPTION
## Summary

- **Worktree-per-run is now optional** for scheduled tasks. Per-task `useWorktree` flag, default **OFF**. When off, the executor short-circuits past all git logic and runs claude directly in `task.workingDirectory` — the folder no longer needs to be a git repo. When on, behavior is unchanged. Migration v6 adds the column and wipes pre-existing scheduled tasks (their worktree-always semantics don't carry over cleanly).
- **Fix: tapping a session in the Scheduled-Task sub-list now actually opens it.** Previously, the detail view set `selectedSession` directly, bypassing `ContentViewModel.selectSession` (window registry / activation / runtime). Wired the sub-list tap to the parent sidebar's `onAction(.select(...))` path so it goes through the same code path as the main list.
- **Fix: sub-list rows now show live status dot, PID, CPU, MEM, hook text.** Previously passed `record.isActive` (a DB snapshot that lags hook events) and looked up runtime by `record.claudeSessionId`, which doesn't match the registry key during the temp-UUID → Claude-id swap. Now resolves the live `ClaudeSession` via `activatedSessions` keyed by stable `tenvySessionId`, falling back to the DB record only for inactive history rows.

## Test plan

- [ ] Create a scheduled task with worktree **off**, in a non-git folder — first run executes in the folder directly, no worktree directory is created, no git is initialized.
- [ ] Create a scheduled task with worktree **on**, in a git folder — first run creates `tenvy/scheduled/<slug>/<ts>` worktree as before.
- [ ] Create a scheduled task with worktree **on**, in a non-git folder, with the "init git on first run" checkbox checked — first run initializes git and creates the worktree.
- [ ] Pre-v6 scheduled tasks are wiped on first launch after upgrade (verified by intent of migration).
- [ ] Open the Scheduled section in the sidebar, tap a task, tap a session row in the sub-list — the session opens in the main view.
- [ ] While a scheduled session is running, its sub-list row shows the live status dot, PID, CPU%, and memory.
- [ ] Inactive history rows show the regular inactive appearance (no PID/CPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)