### PR TITLE
fix: hide unresumable sessions from sidebar

### DIFF
--- a/Tenvy/Features/Session/SessionListView.swift
+++ b/Tenvy/Features/Session/SessionListView.swift
@@ -96,12 +96,22 @@ struct SessionListView: View {
     return sessions.sorted { $0.lastModified > $1.lastModified }
   }
 
-  /// DB-only sessions that aren't represented in the filesystem scan yet. Scheduled-task
-  /// runs sit here until their `.jsonl` is populated with user/assistant content (which
-  /// is what makes `SessionManager` include them). We surface them here so every session
-  /// the app knows about appears in the sidebar — scheduled or not.
+  /// DB-only sessions that aren't represented in the filesystem scan yet but are still
+  /// genuinely resumable. In-flight scheduled-task runs are surfaced via `activeSessions`
+  /// (the second branch picks them up from `activatedSessions` even before `SessionManager`
+  /// sees the `.jsonl`); this list catches the narrower window where a record has a real
+  /// Claude session id and a `.jsonl` on disk but no conversation content yet, so the
+  /// filesystem scan filters it out (`SessionManager.parseSessionFile` requires user/
+  /// assistant/summary lines).
+  ///
+  /// Records without a `claudeSessionId` or with a missing `.jsonl` are excluded — they
+  /// are unresumable ghosts (failed scheduled-task runs, externally deleted session
+  /// files, etc.). Clicking such a row would launch `claude --resume <bogus-id>`, which
+  /// immediately exits with "No conversation found with session ID: …". Failed scheduled
+  /// runs remain reachable through `ScheduledTaskDetailView`'s run history.
   private var supplementarySessions: [ClaudeSession] {
     let filesystemClaudeIds = Set(sessionManager.sessions.map(\.id))
+    let fm = FileManager.default
     return dbSessions.compactMap { record -> ClaudeSession? in
       // Skip records the filesystem scan already covers (matched by Claude session id).
       if let claudeId = record.claudeSessionId, filesystemClaudeIds.contains(claudeId) {
@@ -110,14 +120,18 @@ struct SessionListView: View {
       // Skip plain terminals — they were never Claude sessions and don't belong in the
       // session list.
       if record.isPlainTerminal { return nil }
-      let id = record.claudeSessionId ?? record.tenvySessionId
+      // Resumability gate: Claude can only `--resume` a real session id whose `.jsonl`
+      // still exists. Drop anything that fails either check.
+      guard let claudeId = record.claudeSessionId,
+            let filePath = record.sessionFilePath,
+            fm.fileExists(atPath: filePath) else { return nil }
       return ClaudeSession(
-        id: id,
+        id: claudeId,
         title: record.title,
         projectPath: record.projectPath,
         workingDirectory: record.workingDirectory,
         lastModified: record.lastModifiedAt,
-        filePath: record.sessionFilePath.flatMap(URL.init(fileURLWithPath:)),
+        filePath: URL(fileURLWithPath: filePath),
         isNewSession: false,
         tenvySessionId: record.tenvySessionId
       )


### PR DESCRIPTION
## Summary
- `SessionListView.supplementarySessions` was emitting every DB record that didn't match the filesystem scan, including failed scheduled-task runs (no `claudeSessionId`) and entries whose `.jsonl` had been deleted. The row's id fell back to the tenvy UUID, so clicking it ran `claude --resume <bogus-id>` and showed "No conversation found with session ID: …" in an otherwise blank pane — the same root cause behind the "scheduled task opens empty" symptom.
- Gate the list on actual resumability: only surface records with both a real `claudeSessionId` **and** an existing `.jsonl` on disk. Failed scheduled runs are still reachable through `ScheduledTaskDetailView`'s run history.
- In-flight scheduled-task sessions are unaffected — those come through the `activeSessions` branch (picked up from `activatedSessions` even before `SessionManager` sees the `.jsonl`).

## Test plan
- [ ] Open the app — sidebar should no longer list rows that previously errored with "No conversation found with session ID: …"
- [ ] Click a normal historical session — resumes as before
- [ ] Fire a scheduled task — the spawned window opens with a working terminal, and the run appears in the Active section while alive
- [ ] After the scheduled task ends, confirm the run shows up in `ScheduledTaskDetailView` history but not as a standalone sidebar row if `.jsonl` is missing
- [ ] Manually delete a `.jsonl` from `~/.claude/projects/…/` — the row drops from the sidebar (rather than appearing and failing on click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)